### PR TITLE
feat: add prompt gallery and dataset generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@
 
 🎉 提示词持续更新中。。。
 
+## 🆕 项目改造说明
+- 新增 `scripts/generate-dataset.js`，可将仓库内的 Markdown 案例自动解析为结构化的 `data/prompts.json` 数据集，包含来源、图片、提示词、示例、备注及自动生成的分类标签。
+- 提供全新的前端页面（`index.html` + `assets/`），支持画廊浏览、标签筛选、关键字搜索、案例详情查看以及提示词一键复制。
+- 如需更新数据，先维护 Markdown 文件，再运行 `node scripts/generate-dataset.js` 重新生成 JSON，最后通过任意静态服务器打开 `index.html` 即可体验（例如 `python3 -m http.server 8000`）。
+- 画廊页面会自动聚合所有标签，可快速组合筛选；点击卡片进入详情，可查看全部示例图、提示词及备注。
+
 ## 获取最新提示词？你可以通过这3个渠道。
 <div style="width: 98%;">
 <table>

--- a/assets/app.js
+++ b/assets/app.js
@@ -1,0 +1,467 @@
+const DATA_URL = './data/prompts.json';
+
+const state = {
+  items: [],
+  filteredItems: [],
+  allTags: [],
+  selectedTags: new Set(),
+  searchTerm: '',
+};
+
+const dom = {
+  gallery: document.getElementById('gallery'),
+  emptyState: document.getElementById('emptyState'),
+  tagFilters: document.getElementById('tagFilters'),
+  searchInput: document.getElementById('searchInput'),
+  clearSearch: document.getElementById('clearSearch'),
+  clearFilters: document.getElementById('clearFilters'),
+  resultStats: document.getElementById('resultStats'),
+  modal: document.getElementById('detailModal'),
+  modalTitle: document.getElementById('modalTitle'),
+  modalSource: document.getElementById('modalSource'),
+  modalTags: document.getElementById('modalTags'),
+  modalImages: document.getElementById('modalImages'),
+  modalPrompts: document.getElementById('modalPrompts'),
+  modalExamples: document.getElementById('modalExamples'),
+  modalNotes: document.getElementById('modalNotes'),
+  modalDescription: document.getElementById('modalDescription'),
+  modalClose: document.getElementById('modalClose'),
+  toast: document.getElementById('toast'),
+};
+
+let searchDebounceTimer = null;
+let toastTimer = null;
+
+init();
+
+async function init() {
+  try {
+    const dataset = await fetchData();
+    state.items = dataset.items || [];
+    state.filteredItems = [...state.items];
+    state.allTags = buildAllTags(state.items);
+    renderTagFilters();
+    renderGallery();
+    updateResultStats();
+    bindEvents();
+  } catch (error) {
+    console.error('[prompts] Failed to initialise gallery', error);
+    showToast('数据加载失败，请检查控制台。', true);
+  }
+}
+
+async function fetchData() {
+  const response = await fetch(DATA_URL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch dataset: ${response.status} ${response.statusText}`);
+  }
+  return response.json();
+}
+
+function buildAllTags(items) {
+  const tagSet = new Set();
+  items.forEach((item) => {
+    (item.tags || []).forEach((tag) => tagSet.add(tag));
+  });
+  return Array.from(tagSet).sort((a, b) => a.localeCompare(b, 'zh-CN'));
+}
+
+function bindEvents() {
+  dom.tagFilters.addEventListener('click', onTagClick);
+  dom.clearFilters.addEventListener('click', clearFilters);
+  dom.searchInput.addEventListener('input', handleSearchInput);
+  dom.clearSearch.addEventListener('click', clearSearch);
+  dom.modalClose.addEventListener('click', closeModal);
+  dom.modal.addEventListener('click', (event) => {
+    if (event.target === dom.modal) {
+      closeModal();
+    }
+  });
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !dom.modal.classList.contains('hidden')) {
+      closeModal();
+    }
+  });
+}
+
+function renderTagFilters() {
+  dom.tagFilters.innerHTML = '';
+  if (state.allTags.length === 0) {
+    dom.tagFilters.classList.add('hidden');
+    return;
+  }
+  dom.tagFilters.classList.remove('hidden');
+
+  state.allTags.forEach((tag) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'tag-button';
+    button.textContent = tag;
+    button.dataset.tag = tag;
+    dom.tagFilters.appendChild(button);
+  });
+}
+
+function renderGallery() {
+  dom.gallery.innerHTML = '';
+  if (state.filteredItems.length === 0) {
+    dom.emptyState.classList.remove('hidden');
+    return;
+  }
+  dom.emptyState.classList.add('hidden');
+
+  state.filteredItems.forEach((item) => {
+    const card = document.createElement('article');
+    card.className = 'prompt-card';
+    card.tabIndex = 0;
+    card.setAttribute('role', 'button');
+    card.setAttribute('aria-label', `查看案例 ${item.id}：${item.title}`);
+
+    if (item.coverImage) {
+      const img = document.createElement('img');
+      img.src = item.coverImage;
+      img.alt = `案例 ${item.id}：${item.title}`;
+      img.loading = 'lazy';
+      card.appendChild(img);
+    } else {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'card-placeholder';
+      placeholder.textContent = 'No Image';
+      card.appendChild(placeholder);
+    }
+
+    const body = document.createElement('div');
+    body.className = 'card-body';
+
+    const title = document.createElement('h3');
+    title.className = 'card-title';
+    title.textContent = `案例 ${item.id}：${item.title}`;
+    body.appendChild(title);
+
+    if (item.tags && item.tags.length > 0) {
+      const tagContainer = document.createElement('div');
+      tagContainer.className = 'card-tags';
+      item.tags.slice(0, 4).forEach((tag) => {
+        const chip = document.createElement('span');
+        chip.className = 'tag-chip';
+        chip.textContent = tag;
+        tagContainer.appendChild(chip);
+      });
+      body.appendChild(tagContainer);
+    }
+
+    const meta = document.createElement('div');
+    meta.className = 'card-meta';
+    const promptCount = document.createElement('span');
+    promptCount.textContent = `提示词 ×${item.prompts.length}`;
+    meta.appendChild(promptCount);
+    if (item.examples && item.examples.length > 0) {
+      const exampleCount = document.createElement('span');
+      exampleCount.textContent = `示例 ×${item.examples.length}`;
+      meta.appendChild(exampleCount);
+    }
+    body.appendChild(meta);
+
+    card.appendChild(body);
+    card.addEventListener('click', () => openModal(item));
+    card.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        openModal(item);
+      }
+    });
+    dom.gallery.appendChild(card);
+  });
+}
+
+function onTagClick(event) {
+  const button = event.target.closest('button[data-tag]');
+  if (!button) return;
+  const tag = button.dataset.tag;
+  if (state.selectedTags.has(tag)) {
+    state.selectedTags.delete(tag);
+    button.classList.remove('active');
+  } else {
+    state.selectedTags.add(tag);
+    button.classList.add('active');
+  }
+  applyFilters();
+}
+
+function clearFilters() {
+  if (state.selectedTags.size === 0) return;
+  state.selectedTags.clear();
+  dom.tagFilters.querySelectorAll('.tag-button').forEach((btn) => btn.classList.remove('active'));
+  applyFilters();
+}
+
+function handleSearchInput(event) {
+  const value = event.target.value;
+  state.searchTerm = value;
+  dom.clearSearch.style.display = value ? 'inline-flex' : 'none';
+  if (searchDebounceTimer) window.clearTimeout(searchDebounceTimer);
+  searchDebounceTimer = window.setTimeout(() => {
+    applyFilters();
+  }, 200);
+}
+
+function clearSearch() {
+  if (!state.searchTerm) return;
+  state.searchTerm = '';
+  dom.searchInput.value = '';
+  dom.clearSearch.style.display = 'none';
+  applyFilters();
+}
+
+function applyFilters() {
+  const search = state.searchTerm.trim().toLowerCase();
+  const selectedTags = Array.from(state.selectedTags);
+
+  state.filteredItems = state.items.filter((item) => {
+    if (selectedTags.length > 0) {
+      const hasAllTags = selectedTags.every((tag) => item.tags && item.tags.includes(tag));
+      if (!hasAllTags) return false;
+    }
+
+    if (!search) return true;
+
+    const haystack = [
+      `案例 ${item.id}`,
+      item.title,
+      item.description,
+      ...(item.prompts || []),
+      ...(item.examples || []),
+      ...(item.notes || []),
+      ...(item.tags || []),
+    ]
+      .join('\n')
+      .toLowerCase();
+
+    return haystack.includes(search);
+  });
+
+  renderGallery();
+  updateResultStats();
+}
+
+function updateResultStats() {
+  const total = state.items.length;
+  const filtered = state.filteredItems.length;
+  const tags = state.selectedTags.size;
+  const hasSearch = Boolean(state.searchTerm.trim());
+  const parts = [`共 ${filtered} / ${total} 个案例`];
+  if (tags > 0) parts.push(`标签 ×${tags}`);
+  if (hasSearch) parts.push('已应用搜索');
+  dom.resultStats.textContent = parts.join(' · ');
+}
+
+function openModal(item) {
+  dom.modalTitle.textContent = `案例 ${item.id}：${item.title}`;
+  if (item.source && item.source.url) {
+    dom.modalSource.innerHTML = `来源：<a href="${item.source.url}" target="_blank" rel="noopener">${item.source.name}</a>`;
+  } else {
+    dom.modalSource.textContent = '';
+  }
+
+  renderModalTags(item.tags || []);
+  renderModalImages(item.images || []);
+  renderModalPrompts(item.prompts || []);
+  renderModalExamples(item.examples || []);
+  renderModalNotes(item.notes || []);
+  renderModalDescription(item.description);
+
+  dom.modal.classList.remove('hidden');
+  document.body.classList.add('modal-open');
+}
+
+function closeModal() {
+  dom.modal.classList.add('hidden');
+  document.body.classList.remove('modal-open');
+}
+
+function renderModalTags(tags) {
+  dom.modalTags.innerHTML = '';
+  if (!tags.length) {
+    dom.modalTags.classList.add('hidden');
+    return;
+  }
+  dom.modalTags.classList.remove('hidden');
+  tags.forEach((tag) => {
+    const chip = document.createElement('span');
+    chip.className = 'tag-chip';
+    chip.textContent = tag;
+    dom.modalTags.appendChild(chip);
+  });
+}
+
+function renderModalImages(images) {
+  dom.modalImages.innerHTML = '';
+  if (!images.length) {
+    dom.modalImages.classList.add('hidden');
+    return;
+  }
+  dom.modalImages.classList.remove('hidden');
+  const heading = document.createElement('h3');
+  heading.textContent = '示例图片';
+  dom.modalImages.appendChild(heading);
+
+  const grid = document.createElement('div');
+  grid.className = 'image-grid';
+
+  images.forEach((src, index) => {
+    const img = document.createElement('img');
+    img.src = src;
+    img.alt = `示例图片 ${index + 1}`;
+    img.loading = 'lazy';
+    grid.appendChild(img);
+  });
+
+  dom.modalImages.appendChild(grid);
+}
+
+function renderModalPrompts(prompts) {
+  dom.modalPrompts.innerHTML = '';
+  if (!prompts.length) {
+    dom.modalPrompts.classList.add('hidden');
+    return;
+  }
+  dom.modalPrompts.classList.remove('hidden');
+  const heading = document.createElement('h3');
+  heading.textContent = '提示词';
+  dom.modalPrompts.appendChild(heading);
+
+  prompts.forEach((prompt, index) => {
+    dom.modalPrompts.appendChild(createPromptBlock(prompt, index + 1, '提示词'));
+  });
+}
+
+function renderModalExamples(examples) {
+  dom.modalExamples.innerHTML = '';
+  if (!examples.length) {
+    dom.modalExamples.classList.add('hidden');
+    return;
+  }
+  dom.modalExamples.classList.remove('hidden');
+  const heading = document.createElement('h3');
+  heading.textContent = '示例提示';
+  dom.modalExamples.appendChild(heading);
+
+  examples.forEach((example, index) => {
+    dom.modalExamples.appendChild(createPromptBlock(example, index + 1, '示例'));
+  });
+}
+
+function renderModalNotes(notes) {
+  dom.modalNotes.innerHTML = '';
+  if (!notes.length) {
+    dom.modalNotes.classList.add('hidden');
+    return;
+  }
+  dom.modalNotes.classList.remove('hidden');
+  const heading = document.createElement('h3');
+  heading.textContent = '提示';
+  dom.modalNotes.appendChild(heading);
+
+  const list = document.createElement('ul');
+  list.className = 'note-list';
+  notes.forEach((note) => {
+    const item = document.createElement('li');
+    item.textContent = note;
+    list.appendChild(item);
+  });
+  dom.modalNotes.appendChild(list);
+}
+
+function renderModalDescription(description) {
+  dom.modalDescription.innerHTML = '';
+  if (!description) {
+    dom.modalDescription.classList.add('hidden');
+    return;
+  }
+  dom.modalDescription.classList.remove('hidden');
+  const heading = document.createElement('h3');
+  heading.textContent = '补充描述';
+  const paragraph = document.createElement('div');
+  paragraph.className = 'description-block';
+  paragraph.textContent = description;
+  dom.modalDescription.appendChild(heading);
+  dom.modalDescription.appendChild(paragraph);
+}
+
+function createPromptBlock(text, index, label) {
+  const block = document.createElement('div');
+  block.className = 'prompt-block';
+
+  const meta = document.createElement('div');
+  meta.className = 'prompt-meta';
+  const left = document.createElement('span');
+  left.textContent = `${label} ${index}`;
+  meta.appendChild(left);
+
+  const copy = document.createElement('button');
+  copy.type = 'button';
+  copy.className = 'copy-btn';
+  copy.textContent = '复制';
+  copy.addEventListener('click', (event) => {
+    event.stopPropagation();
+    copyPrompt(text, copy);
+  });
+
+  meta.appendChild(copy);
+  block.appendChild(meta);
+
+  const code = document.createElement('pre');
+  code.textContent = text;
+  block.appendChild(code);
+
+  return block;
+}
+
+async function copyPrompt(text, button) {
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      await navigator.clipboard.writeText(text);
+    } else {
+      fallbackCopy(text);
+    }
+    animateCopyButton(button);
+    showToast('提示词已复制 ✅');
+  } catch (error) {
+    console.warn('[prompts] clipboard API failed, fallback', error);
+    fallbackCopy(text);
+    animateCopyButton(button, true);
+    showToast('已使用备用方式复制', false);
+  }
+}
+
+function fallbackCopy(text) {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  document.execCommand('copy');
+  document.body.removeChild(textarea);
+}
+
+function animateCopyButton(button, withWarning = false) {
+  button.textContent = withWarning ? '已复制（备用）' : '已复制';
+  button.disabled = true;
+  setTimeout(() => {
+    button.textContent = '复制';
+    button.disabled = false;
+  }, 1800);
+}
+
+function showToast(message, isError = false) {
+  if (!dom.toast) return;
+  dom.toast.textContent = message;
+  dom.toast.classList.toggle('error', isError);
+  dom.toast.classList.remove('hidden');
+  if (toastTimer) window.clearTimeout(toastTimer);
+  toastTimer = window.setTimeout(() => {
+    dom.toast.classList.add('hidden');
+  }, 2200);
+}

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,476 @@
+:root {
+  color-scheme: dark;
+  --bg: #0b1220;
+  --bg-elevated: #111c31;
+  --bg-card: #15253f;
+  --border: rgba(148, 163, 184, 0.2);
+  --primary: #38bdf8;
+  --primary-soft: rgba(56, 189, 248, 0.1);
+  --text: #e2e8f0;
+  --text-subtle: #94a3b8;
+  --danger: #f87171;
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --radius-sm: 8px;
+  --shadow-soft: 0 14px 40px rgba(15, 23, 42, 0.45);
+  --transition: 180ms ease;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at 10% 10%, rgba(56, 189, 248, 0.12), transparent 35%),
+    radial-gradient(circle at 90% 5%, rgba(168, 85, 247, 0.07), transparent 40%),
+    var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+a {
+  color: var(--primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  padding: 2.4rem clamp(1.8rem, 4vw, 3rem);
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.92) 0%, rgba(15, 23, 42, 0.8) 60%, transparent 100%);
+  backdrop-filter: blur(18px);
+}
+
+.header-top {
+  max-width: 960px;
+  margin-bottom: 1.4rem;
+}
+
+.tagline {
+  margin: 0.8rem 0 0;
+  color: var(--text-subtle);
+  font-size: 1rem;
+}
+
+.control-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 1rem;
+}
+
+.search-field {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.6rem 0.9rem;
+  min-width: min(360px, 100%);
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.search-field:focus-within {
+  border-color: rgba(56, 189, 248, 0.6);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.15);
+}
+
+.search-icon {
+  font-size: 1rem;
+  opacity: 0.6;
+}
+
+#searchInput {
+  flex: 1;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 1rem;
+  outline: none;
+}
+
+.ghost-btn {
+  border: none;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--text-subtle);
+  padding: 0.35rem 0.75rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.ghost-btn:hover {
+  background: rgba(148, 163, 184, 0.3);
+  color: var(--text);
+}
+
+.ghost-btn:active {
+  transform: translateY(1px);
+}
+
+.clear-filter-btn {
+  padding: 0.45rem 0.9rem;
+}
+
+#clearSearch {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 1.8rem;
+  height: 1.8rem;
+  font-size: 0.85rem;
+}
+
+.result-stats {
+  margin-left: auto;
+  color: var(--text-subtle);
+  font-size: 0.95rem;
+}
+
+.tag-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  max-height: 160px;
+  overflow-y: auto;
+  padding-right: 0.2rem;
+}
+
+.tag-button {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-subtle);
+  font-size: 0.88rem;
+  cursor: pointer;
+  transition: transform var(--transition), border-color var(--transition), background var(--transition), color var(--transition);
+}
+
+.tag-button:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.6);
+  color: var(--text);
+}
+
+.tag-button.active {
+  background: var(--primary-soft);
+  border-color: rgba(56, 189, 248, 0.8);
+  color: var(--primary);
+}
+
+main {
+  padding: 0 clamp(1.4rem, 4vw, 3rem) 3rem;
+}
+
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.6rem;
+}
+
+.prompt-card {
+  background: rgba(17, 25, 40, 0.8);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.4);
+  backdrop-filter: blur(10px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: transform var(--transition), border-color var(--transition);
+  cursor: pointer;
+}
+
+.prompt-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.prompt-card img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.card-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  background: rgba(148, 163, 184, 0.08);
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.card-body {
+  padding: 1.1rem 1.2rem 1.3rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.card-title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+}
+
+.card-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.tag-chip {
+  padding: 0.2rem 0.65rem;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.12);
+  color: #bae6fd;
+}
+
+.card-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--text-subtle);
+  font-size: 0.82rem;
+}
+
+.card-meta span + span::before {
+  content: '•';
+  margin: 0 0.4rem;
+  color: rgba(148, 163, 184, 0.4);
+}
+
+.empty-state {
+  margin-top: 3rem;
+  text-align: center;
+  color: var(--text-subtle);
+  font-size: 1rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 15, 0.72);
+  backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 3rem);
+  z-index: 999;
+}
+
+.modal-content {
+  position: relative;
+  width: min(960px, 100%);
+  max-height: 90vh;
+  padding: clamp(1.4rem, 2vw, 2.1rem);
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.1), transparent 40%), rgba(8, 17, 35, 0.98);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow-soft);
+  overflow-y: auto;
+}
+
+.modal-close {
+  position: absolute;
+  top: 1.1rem;
+  right: 1.1rem;
+  border: none;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 999px;
+  width: 2.2rem;
+  height: 2.2rem;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 1rem;
+  transition: background var(--transition);
+}
+
+.modal-close:hover {
+  background: rgba(56, 189, 248, 0.7);
+}
+
+.modal-header {
+  margin-bottom: 1rem;
+}
+
+.modal-source {
+  margin-top: 0.4rem;
+  font-size: 0.9rem;
+  color: var(--text-subtle);
+}
+
+.modal-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1.4rem;
+}
+
+.modal-tags .tag-chip {
+  background: rgba(56, 189, 248, 0.18);
+  color: #e0f2fe;
+}
+
+.modal-section {
+  margin-bottom: 1.6rem;
+}
+
+.modal-section h3 {
+  margin-bottom: 0.8rem;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.9rem;
+}
+
+.image-grid img {
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  object-fit: cover;
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.prompt-block {
+  position: relative;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.7);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+}
+
+.prompt-block + .prompt-block {
+  margin-top: 1rem;
+}
+
+.prompt-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.6rem;
+  color: var(--text-subtle);
+  font-size: 0.85rem;
+}
+
+.copy-btn {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.75rem;
+  background: rgba(56, 189, 248, 0.12);
+  color: #bae6fd;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition), transform var(--transition);
+}
+
+.copy-btn:hover {
+  background: rgba(56, 189, 248, 0.25);
+  color: #f0f9ff;
+  transform: translateY(-1px);
+}
+
+pre {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: 'JetBrains Mono', 'Fira Code', 'SFMono-Regular', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  font-size: 0.9rem;
+  color: #f8fafc;
+}
+
+.note-list {
+  padding-left: 1.2rem;
+  margin: 0.3rem 0 0;
+  color: var(--text-subtle);
+}
+
+.description-block {
+  color: var(--text-subtle);
+  background: rgba(148, 163, 184, 0.08);
+  border-radius: var(--radius-md);
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(15, 23, 42, 0.85);
+  color: #f8fafc;
+  padding: 0.7rem 1.2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  box-shadow: 0 15px 40px rgba(15, 23, 42, 0.5);
+  backdrop-filter: blur(10px);
+  font-size: 0.95rem;
+  z-index: 1000;
+}
+
+.toast.error {
+  border-color: rgba(248, 113, 113, 0.65);
+  color: #fee2e2;
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    position: static;
+    padding-top: 1.8rem;
+  }
+
+  .control-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .result-stats {
+    margin-left: 0;
+  }
+
+  .gallery {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .modal-content {
+    max-height: 88vh;
+  }
+}

--- a/data/prompts.json
+++ b/data/prompts.json
@@ -1,0 +1,8993 @@
+{
+  "generatedAt": "2025-10-14T10:57:04.195Z",
+  "total": 333,
+  "items": [
+    {
+      "id": 333,
+      "slug": "prompt-333",
+      "title": "女生坐沙发上",
+      "source": {
+        "name": "@IamEmily2050",
+        "url": "https://x.com/IamEmily2050/status/1975554358495654236"
+      },
+      "images": [
+        "images/333.jpeg"
+      ],
+      "prompts": [
+        "{\n  \"style\": \"High-key studio portrait, direct flash aesthetic, East Asian social media style (e.g., Ulzzang, Douyin), stylized beauty retouching.\",\n  \"output\": {\n    \"color_profile\": \"sRGB\",\n    \"render_intent\": \"photo\"\n  },\n  \"subject\": {\n    \"category\": \"human\",\n    \"gender_presentation\": \"female\",\n    \"ethnicity\": \"East Asian (e.g., Korean, Chinese)\",\n    \"age_bracket\": \"young_adult\",\n    \"body\": {\n      \"build\": \"slim\",\n      \"proportions\": \"natural human anatomy\",\n      \"posture\": \"relaxed on sofa, seated casually\",\n      \"pose\": \"seated, legs crossed and tucked close to body\",\n      \"gesture\": \"Right hand raised, fingers loosely curled, back of fingers/knuckles gently supporting the chin and lower cheek.\",\n      \"head_tilt_deg\": 5\n    },\n    \"face\": {\n      \"expression\": \"Playful, alluring\",\n      \"gaze\": \"right eye direct to camera\",\n      \"eye_action\": \"winking with the left eye\",\n      \"skin_tone\": \"Very pale porcelain (lightened aesthetic)\",\n      \"makeup\": \"Stylized K-Beauty/Douyin look: flawless matte base, strong pink blush high on cheeks, pink gradient lips, defined brows, light eyeliner, emphasized Aegyo-sal\",\n      \"features\": \"small beauty mark/mole under the left eye\"\n    },\n    \"hair\": {\n      \"length\": \"long\",\n      \"style\": \"messy high updo/bun with loose strands and curtain bangs\",\n      \"color\": \"dark brown\"\n    },\n    \"wardrobe\": {\n      \"top\": \"white fitted cropped camisole\",\n      \"outerwear\": \"light gray zip hoodie, worn open and slightly slipping off both shoulders\",\n      \"bottom\": \"white lounge shorts with drawstring\",\n      \"footwear\": \"barefoot\"\n    }\n  },\n  \"environment\": {\n    \"location\": \"studio or minimalist interior\",\n    \"set\": \"black leather sofa against a plain white or light gray wall\",\n    \"props\": \"Silver laptop (Apple MacBook, logo visible) placed on the cushion to the subject's right (camera left)\"\n  },\n  \"lighting\": {\n    \"key\": {\n      \"source\": \"strobe/flash\",\n      \"modifier\": \"Bare reflector or direct flash (hard source)\",\n      \"position\": \"Near camera axis, slightly camera-right and above eye line\",\n      \"effect\": \"Crisp, dark, well-defined cast shadows on the wall directly behind subject; strong specular highlights on skin and sofa leather.\"\n    },\n    \"fill\": {\n      \"type\": \"minimal/none\"\n    },\n    \"ambient\": \"suppressed\",\n    \"white_balance_K\": 5800\n  },\n  \"camera\": {\n    \"system\": \"Digital Camera\",\n    \"sensor\": \"full-frame equivalent\",\n    \"lens\": {\n      \"type\": \"prime\",\n      \"focal_length_mm\": 50\n    },\n    \"exposure\": {\n      \"iso\": 100,\n      \"aperture_f\": 4.0,\n      \"metering\": \"Bright exposure, high-key aesthetic\"\n    },\n    \"focus\": {\n      \"target\": \"near eye (right eye)\",\n      \"depth_of_field\": \"moderate\"\n    },\n    \"framing\": {\n      \"orientation\": \"vertical\",\n      \"crop\": \"mid-thigh to head with room above hair\",\n      \"angle\": \"eye-level\",\n      \"composition\": \"subject centrally framed\"\n    }\n  },\n  \"color_grade\": {\n    \"look\": \"Bright, clean, slightly cool tone\",\n    \"contrast\": \"High contrast\",\n    \"saturation\": \"moderate, emphasized pinks\"\n  },\n  \"postprocess\": {\n    \"noise_reduction\": \"high\",\n    \"texture\": \"Highly smoothed skin, poreless appearance ('porcelain doll' or 'beauty filter' effect)\",\n    \"sharpen\": \"selective on eyes/lashes\",\n    \"blemish_control\": \"Complete removal of all blemishes and texture.\"\n  },\n  \"quality_targets\": [\n    \"accurate limb lengths and joint angles\",\n    \"correct finger count and articulation\",\n    \"realistic fabric tension and folds\",\n    \"accurate winking expression\"\n  ],\n  \"negative_prompt\": [\n    \"no altered or exaggerated body proportions\",\n    \"no extra or fused fingers\",\n    \"no realistic skin texture, pores, or blemishes\",\n    \"no text or watermarks (excluding specified logos)\",\n    \"no extreme wide-angle distortion\",\n    \"no NSFW content\",\n    \"no dark/moody lighting\",\n    \"no warm tones\"\n  ]\n}",
+        "{\n\"style\": \"高调影棚人像，闪光灯直击美感，东亚社交媒体风格（例如Ulzzang、抖音），风格化美颜修图。\",\n“输出”： {\n\"color_profile\": \"sRGB\",\n\"render_intent\": \"照片\"\n}，\n“主题”： {\n“类别”：“人类”，\n\"gender_presentation\": \"女性\",\n\"ethnicity\": \"东亚人（例如韩国人、中国人）\",\n\"age_bracket\": \"young_adult\",\n“身体”： {\n\"build\": \"slim\",\n\"比例\": \"自然人体解剖学\",\n\"posture\": \"放松地坐在沙发上，随意地坐着\",\n\"pose\": \"坐着，双腿交叉，身体紧贴身体\",\n\"gesture\": \"右手举起，手指松散地卷曲，手指背面/指关节轻轻支撑下巴和下脸颊。\",\n“头部倾斜度”：5\n}，\n“脸”： {\n\"expression\": \"俏皮、诱人\",\n\"gaze\": \"右眼直视相机\",\n\"eye_action\": \"用左眼眨眼\",\n\"skin_tone\": \"非常苍白的瓷器（明亮的美学）\",\n\"makeup\": \"风格化的韩妆/抖音妆容：完美哑光底妆，脸颊上浓重的粉色腮红，粉色渐变唇妆，清晰的眉毛，淡淡的眼线，强调的撒娇，\n\"features\": \"左眼下方有一颗小美人痣\"\n}，\n“头发”： {\n\"length\": \"长\",\n\"style\": \"凌乱的高髻/发髻，散落的发束和窗帘刘海\",\n“颜色”：“深棕色”\n}，\n“衣柜”： {\n\"top\": \"白色修身短款吊带背心\",\n“外套”：“浅灰色拉链连帽衫，敞开穿着，双肩略微滑落”，\n\"bottom\": \"白色抽绳休闲短裤\",\n“鞋类”：“赤脚”\n}\n}，\n“环境”： {\n\"location\": \"工作室或简约室内\",\n\"set\": \"黑色皮沙发搭配纯白色或浅灰色墙壁\",\n\"props\": \"银色笔记本电脑（Apple MacBook，标志可见）放置在拍摄对象右侧的垫子上（相机左侧）\"\n}，\n“灯光”： {\n“钥匙”： {\n\"source\": \"频闪/闪光\",\n\"modifier\": \"裸露的反射器或直接闪光（硬源）\",\n\"position\": \"靠近相机轴，略微位于相机右侧且高于视线\",\n\"effect\": \"拍摄对象正后方的墙壁上投射出清晰、暗淡、轮廓分明的阴影；皮肤和沙发皮革上出现强烈的镜面高光。\"\n}，\n“充满”： {\n“类型”：“最小/无”\n}，\n“环境”：“抑制”，\n“白平衡K”：5800\n}，\n“相机”： {\n\"system\": \"数码相机\",\n“传感器”：“全画幅等效”，\n“镜片”： {\n“类型”：“主要”，\n“焦距毫米”：50\n}，\n“接触”： {\n\"iso\": 100,\n\"aperture_f\": 4.0,\n“测光”：“明亮的曝光，高调的美感”\n}，\n“重点”： {\n\"target\": \"近眼（右眼）\",\n\"depth_of_field\": \"中等\"\n}，\n“框架”：{\n“方向”：“垂直”，\n\"crop\": \"从大腿中部到头部，头发上方有空间\",\n\"角度\": \"视线水平\",\n\"composition\": \"主体居中\"\n}\n}，\n“颜色等级”：{\n\"look\": \"明亮、干净、略带冷色调\",\n\"contrast\": \"高对比度\",\n“饱和度”：“中等，强调粉红色”\n}，\n“后处理”：{\n\"noise_reduction\": \"高\",\n\"texture\": \"肌肤高度光滑，无毛孔外观（‘瓷娃娃’或‘美颜滤镜’效果）\",\n“锐化”：“选择性地针对眼睛/睫毛”，\n\"blemish_control\": \"彻底去除所有瑕疵和纹理。\"\n}，\n\"质量目标\": [\n“准确的肢体长度和关节角度”，\n“正确的手指计数和发音”，\n“逼真的织物张力和褶皱”，\n“精准的眨眼表情”\n]，\n\"negative_prompt\": [\n“没有改变或夸大身体比例”，\n“没有多余的或融合的手指”，\n“没有真实的皮肤纹理、毛孔或瑕疵”，\n“无文字或水印（指定徽标除外）”，\n“没有极端的广角畸变”，\n“禁止 NSFW 内容”，\n“没有黑暗/忧郁的灯光”，\n“没有暖色调”\n]\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "landscape",
+        "logo",
+        "minimalist",
+        "nature",
+        "photography",
+        "portrait"
+      ],
+      "coverImage": "images/333.jpeg"
+    },
+    {
+      "id": 332,
+      "slug": "prompt-332",
+      "title": "女生镜子自拍",
+      "source": {
+        "name": "@dotey",
+        "url": "https://x.com/dotey/status/1976485558319722711"
+      },
+      "images": [
+        "images/332.jpeg"
+      ],
+      "prompts": [
+        "### **场景**\n镜子自拍，御宅族电脑角落，蓝色调\n\n---\n\n### **主体**\n* **性别表现**: 女性\n* **年龄段**: 25岁左右\n* **种族**: 东亚\n* **身材**: 苗条，腰线分明；身材比例自然\n* **肤色**: 浅中性色调\n* **发型**:\n    * **长度**: 及腰长发\n    * **样式**: 直发，发尾微卷\n    * **颜色**: 中等棕色\n* **姿势**:\n    * **站姿**: 站立，轻微的对立式平衡站姿（contrapposto）\n    * **右手**: 手持手机挡住脸（身份被遮挡）\n    * **左臂**: 在躯干旁自然下垂\n    * **躯干**: 身体轻微后仰；露出腰腹\n* **着装**:\n    * **上衣**: 浅蓝色短款针织开衫，扣上前两颗纽扣；隐约可见蓝色法式内衣\n    * **下装**: 牛仔超短裤，两侧臀部各有一个蓝色缎带蝴蝶结\n    * **袜子**: 蓝白横条纹过膝长袜\n    * **配饰**: 蓝色可爱吉祥物手机壳\n\n---\n\n### **环境**\n* **描述**: 从挂墙镜中看到的卧室电脑角落\n* **陈设**:\n    * 白色书桌\n    * 单显示器，显示着柔和的蓝色壁纸（没有可读的文字）\n    * 机械键盘，白色键帽，放在蓝色桌垫上\n    * 鼠标，放在小号蓝色鼠标垫上\n    * PC主机在右侧，带有蓝色机箱灯效\n    * PC主机上或附近有三个动漫手办\n    * 墙上贴着一张佛塔海报\n    * 猫形台灯，带有蓝色点缀\n    * 一杯透明的玻璃水杯\n    * 窗边（镜头左侧）有一株高大的绿叶植物\n* **颜色替换**: 将所有原先的粉色元素（衣物和房间）替换为蓝色（婴儿蓝 -> 天空蓝/长春花蓝）。\n\n---\n\n### **灯光**\n* **光源**: 来自镜头左侧大窗户的日光，透过薄纱窗帘\n* **光线质感**: 柔和的漫射光\n* **白平衡 (K)**: 5200\n\n---\n\n### **相机**\n* **模式**: 智能手机后置摄像头通过镜子拍摄（无肖像/虚化模式）\n* **等效焦距 (mm)**: 26\n* **距离 (米)**:\n    * 主体到镜子: 0.6\n    * 相机到镜子: 0.5\n* **曝光**:\n    * 光圈 (f): 1.8\n    * 感光度 (ISO): 100\n    * 快门速度 (秒): 0.01\n    * 曝光补偿 (EV): -0.3\n* **对焦**: 对焦于镜中影像的躯干和短裤\n* **景深**: 自然的智能手机景深（深景深）；背景清晰可辨，无人为模糊\n* **构图**:\n    * **宽高比**: 1:1\n    * **裁剪**: 从头顶到大腿中部；画面包含书桌、显示器、PC主机和植物\n    * **角度**: 从镜子的视角轻微俯拍\n    * **构图备注**: 保持主体居中；为避免广角边缘拉伸，可以站远一些再进行方形裁剪\n\n---\n\n### **负面提示词**\n* 任何地方出现粉色/品红色\n* 美颜滤镜/磨皮皮肤；没有毛孔的外观\n* 夸张或扭曲的人体结构\n* NSFW，透视面料，走光\n* 商标，品牌名，可读的用户界面文本\n* 虚假的人像模式模糊，CGI/插画感"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "illustration",
+        "landscape",
+        "nature",
+        "paper-craft",
+        "portrait",
+        "poster",
+        "ui"
+      ],
+      "coverImage": "images/332.jpeg"
+    },
+    {
+      "id": 331,
+      "slug": "prompt-331",
+      "title": "走廊上的女性",
+      "source": {
+        "name": "@IamEmily2050",
+        "url": "https://x.com/IamEmily2050/status/1974108838929576299"
+      },
+      "images": [
+        "images/331.jpeg"
+      ],
+      "prompts": [
+        "{\n  \"scene\": {\n    \"environment\": {\n      \"location_type\": \"modern gallery hallway\",\n      \"left_wall\": \"black-and-white optical swirl mural, matte finish\",\n      \"right_wall\": \"framed monochrome manga panels with sparse Japanese onomatopoeia\",\n      \"floor\": \"light gray polished tile with 2x2 m matte gray vinyl sheet under subject to kill reflections\",\n      \"depth\": \"short corridor depth with subtle falloff\",\n      \"clutter\": \"none\"\n    },\n    \"time\": \"indoors, artificial light\",\n    \"mood\": \"cool, composed, slightly mysterious\",\n    \"color_palette\": \"neutral-cool grays, olive top, desaturated denim blues\"\n  },\n  \"subject\": {\n    \"type\": \"human\",\n    \"gender\": \"female\",\n    \"approx_age\": \"early 20s\",\n    \"appearance\": {\n      \"skin_tone\": \"fair-light with neutral undertone\",\n      \"hair\": \"jet-black, very long, straight, center part; clean specular sheen\",\n      \"face\": \"oval face, soft makeup, subtle gloss on lips, light eyeliner and mascara\",\n      \"earrings\": \"large silver hoop earrings\"\n    },\n    \"wardrobe\": {\n      \"top\": \"fitted olive/khaki ribbed tank with small rhinestone cross motifs (check glue before shoot)\",\n      \"bottom\": \"high-waisted distressed denim shorts with heavy frayed hem and beige repair patches (tape rear hem flat)\",\n      \"footwear\": \"out_of_frame\"\n    },\n    \"pose\": {\n      \"stance\": \"leans back and slightly left with head resting against mural wall\",\n      \"torso\": \"relaxed, angled 10–15° to camera\",\n      \"arms_hands\": \"right arm behind torso/out_of_frame, left arm relaxed by side\",\n      \"expression\": \"calm, neutral-to-soft gaze past camera\",\n      \"chin\": \"slightly down; head tilt toward left shoulder\"\n    }\n  },\n  \"framing_composition\": {\n    \"shot_type\": \"mid-thigh portrait (three-quarter length)\",\n    \"orientation\": \"vertical\",\n    \"framing\": \"subject placed on left third; right third shows manga panels\",\n    \"leading_lines\": \"doorframe/panel edges vertical; swirl mural adds texture without overpowering subject\",\n    \"background_separation\": \"subtle; background softly defocused but still readable\"\n  },\n  \"camera\": {\n    \"sensor\": \"full-frame mirrorless\",\n    \"lens\": {\n      \"focal_length_mm\": 50,\n      \"type\": \"prime\",\n      \"character\": \"neutral rendering, low distortion\"\n    },\n    \"settings\": {\n      \"aperture\": \"f/3.2\",\n      \"shutter_speed\": \"1/250\",\n      \"iso\": 400,\n      \"white_balance\": \"custom grey-card @ 4600 K\",\n      \"focus\": \"eye-AF + 3-frame focus bracket (±1 cm)\",\n      \"stabilisation\": \"IBIS on\"\n    },\n    \"perspective\": \"camera at chest level; minimal keystoning; maintain straight verticals\"\n  },\n  \"lighting\": {\n    \"key\": \"broad, soft overhead/ceiling panel light\",\n    \"fill\": \"60×60 cm white bounce 30 cm below bust line, ~1.3 stops under key\",\n    \"rim\": \"narrow 1×2 ft strip-light behind subject camera-right, ½ stop over key\",\n    \"quality\": \"soft, diffuse; no hard shadows\",\n    \"exposure_target\": \"skin at ~65 IRE; rhinestones clipped < 90 IRE\",\n    \"specular_control\": \"micro-specular on hair; avoid plastic skin sheen\"\n  },\n  \"rendering_intent\": {\n    \"photorealism\": \"high\",\n    \"texture\": \"retain fabric weave, denim fray strands, hair strands\",\n    \"background_text_policy\": \"allow only existing manga panel text; do not invent extra signage or captions\"\n  },\n  \"post_processing\": {\n    \"color_grade\": \"neutral-cool base with gentle contrast curve; slight cyan in shadows, warm bias on skin\",\n    \"tone_curve\": \"soft S-curve (lift shadows +3, compress highlights -5)\",\n    \"clarity_texture\": \"clarity -5 on skin via masked adjustment; texture +5 on denim/frayed hem only (separate mask)\",\n    \"noise_reduction\": \"luma 10, chroma 15\",\n    \"sharpening\": \"amount 40, radius 0.7, detail 25, masking 60 (protect background)\",\n    \"vignette\": \"subtle -0.1 EV centre-weighted\",\n    \"geometry\": \"verticals upright; crop 4:5 with space above head and right-side manga visible\",\n  }",
+        "{\n“场景”： {\n“环境”： {\n\"location_type\": \"现代画廊走廊\",\n\"left_wall\": \"黑白光学漩涡壁画，哑光饰面\",\n\"right_wall\": \"带有稀疏日语拟声词的单色漫画面板\",\n“地板”：“浅灰色抛光瓷砖，铺有 2x2 米哑光灰色乙烯基板，以消除反射”，\n\"depth\": \"短走廊深度，具有微妙的衰减\",\n“杂乱”：“无”\n}，\n\"time\": \"室内，人造光\",\n\"mood\": \"冷静、沉着、略带神秘\",\n\"color_palette\": \"中性冷灰色、橄榄色上衣、去饱和牛仔蓝\"\n}，\n“主题”： {\n“类型”：“人类”，\n\"性别\": \"女\",\n\"approx_age\": \"20 岁出头\",\n“外貌”： {\n\"skin_tone\": \"白皙，中性底色\",\n“头发”：“乌黑，很长，直，中分；干净的镜面光泽”，\n\"face\": \"椭圆脸，淡妆，唇彩淡淡，眼线和睫毛膏淡淡的\",\n“耳环”：“大号银环耳环”\n}，\n“衣柜”： {\n\"top\": \"修身橄榄色/卡其色罗纹背心，饰有小水钻十字图案（拍摄前请检查胶水）\",\n\"bottom\": \"高腰破洞牛仔短裤，下摆磨损严重，配有米色修片（后摆用胶带平整粘贴）\",\n“footwear”：“out_of_frame”\n}，\n“姿势”：{\n\"stance\": \"身体向后稍微向左倾斜，头靠在壁画上\",\n“躯干”：“放松，与相机呈 10-15° 角”，\n\"arms_hands\": \"右臂在躯干后方/超出框架，左臂在身体侧面放松\",\n“表情”：“平静、中性到柔和的目光穿过镜头”，\n“下巴”：“稍微向下；头向左肩倾斜”\n}\n}，\n“framing_composition”：{\n\"shot_type\": \"大腿中部肖像（四分之三长度）\",\n“方向”：“垂直”，\n\"framing\": \"主体放置在左边三分之一处；右边三分之一处显示漫画面板\",\n\"leading_lines\": \"门框/面板边缘垂直；漩涡壁画增添了纹理，但又不会掩盖主题\",\n\"background_separation\": \"微妙；背景轻微散焦但仍可读\"\n}，\n“相机”： {\n“传感器”：“全画幅无反光镜”，\n“镜片”： {\n\"焦距毫米\": 50,\n“类型”：“主要”，\n“character”：“中性渲染，低失真”\n}，\n“设置”： {\n\"光圈\": \"f/3.2\",\n\"shutter_speed\": \"1/250\",\n“iso”：400，\n\"white_balance\": \"自定义灰卡 @ 4600 K\",\n\"focus\": \"眼部自动对焦 + 3 帧对焦框 (±1 cm)\",\n“稳定”：“IBIS开启”\n}，\n“视角”：“摄像机位于胸部高度；最小梯形失真；保持垂直线”\n}，\n“灯光”： {\n\"key\": \"宽阔、柔和的顶灯/天花板面板灯\",\n\"fill\": \"60×60 厘米白色反射镜，位于胸围线以下 30 厘米处，主光圈下方约 1.3 档\",\n\"rim\": \"1×2 英尺窄条形灯位于拍摄对象相机右侧后方，比主光高出 ½ 档\",\n“质量”：“柔和，漫反射；无硬阴影”，\n\"exposure_target\": \"皮肤 ~65 IRE；水钻修剪 < 90 IRE\",\n\"specular_control\": \"头发上的微镜面；避免塑料皮肤光泽\"\n}，\n“渲染意图”：{\n\"照片写实主义\": \"高\",\n\"texture\": \"保留织物编织、牛仔布磨损线、发丝\",\n\"background_text_policy\": \"仅允许现有的漫画面板文本；不要发明额外的标志或标题\"\n}，\n“后处理”：{\n\"color_grade\": \"中性冷色调，对比度曲线柔和；阴影中略带青色，皮肤上偏暖色\",\n\"tone_curve\": \"柔和的 S 曲线（提升阴影 +3，压缩高光 -5）\",\n\"clarity_texture\": \"通过蒙版调整，皮肤的清晰度为 -5；仅牛仔布/磨损下摆的纹理为 +5（单独蒙版）\",\n\"noise_reduction\": \"亮度 10，色度 15\",\n\"sharpening\": \"数量 40，半径 0.7，细节 25，遮罩 60（保护背景）\",\n\"vignette\": \"微妙的 -0.1 EV 中央重点\",\n\"geometry\": \"垂直竖直；裁剪比例为 4:5，头部上方有空间，右侧漫画可见\",\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "interior",
+        "landscape",
+        "logo",
+        "minimalist",
+        "nature",
+        "photography",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/331.jpeg"
+    },
+    {
+      "id": 330,
+      "slug": "prompt-330",
+      "title": "照片级真实感室内躺姿人像",
+      "source": {
+        "name": "@IamEmily2050",
+        "url": "https://x.com/IamEmily2050/status/1976068430798389550"
+      },
+      "images": [
+        "images/330.jpeg"
+      ],
+      "prompts": [
+        "{\n\"photorealistic_indoor_reclining_portrait\",\n  \"style\": \"Natural editorial portrait; lifelike texture; minimal, tasteful retouching.\",\n  \"output\": { \"aspect_ratio\": \"9:16\", \"resolution_px\": [1440, 2560], \"color_profile\": \"sRGB\" },\n\n  \"subject\": {\n    \"category\": \"human\",\n    \"gender_presentation\": \"female\",\n    \"ethnicity\": \"East Asian\",\n    \"age_bracket\": \"young_adult\",\n    \"body\": {\n      \"build\": \"slim with realistic proportions\",\n      \"bust\": \"fuller bust (natural C–D cup), proportional to frame; gentle natural slope, supportive shaping—no extreme push-up\",\n      \"skin_tone\": \"light neutral with natural variation\"\n    },\n    \"pose\": {\n      \"orientation\": \"reclining on back, relaxed\",\n      \"right_arm\": \"raised above head, fingers lightly touching hairline\",\n      \"left_arm\": \"bent across torso, hand resting on midriff\",\n      \"head\": \"slightly tilted toward camera left\"\n    },\n    \"face\": {\n      \"shape\": \"oval with mild asymmetry and natural cheek volume\",\n      \"expression\": \"soft and open\",\n      \"gaze\": \"direct to camera\"\n    },\n    \"eyes\": {\n      \"description\": \"natural-size, lively but realistic\",\n      \"color\": \"neutral gray-blue (low saturation)\",\n      \"size_ratio\": { \"iris_fraction_of_visible_eye\": 0.29, \"pupil_fraction_of_iris\": 0.27 },\n      \"details\": {\n        \"limbal_ring_strength\": 0.08,\n        \"sclera_brightness_Lstar\": 78,\n        \"sclera_texture\": \"fine veins and faint tear meniscus on lower lid\",\n        \"catchlights\": \"two soft rectangular window reflections about 10% of iris width\",\n        \"specular_quality\": \"satin (no glassy glare)\",\n        \"iris_texture\": \"visible stromal fibers and subtle color noise\"\n      }\n    },\n    \"makeup\": \"sheer base preserving pores; soft peach blush; brown mascara/liner; taupe eyeshadow; hydrated nude lips\",\n    \"hair\": { \"length\": \"long\", \"style\": \"half-up with bun, slight wave; a few flyaways visible\", \"color\": \"natural black\" },\n    \"wardrobe\": {\n      \"outfit\": \"blue top with Gucci shorts\",\n      \"top\": \"powder-blue cropped bustier with sweetheart neckline and structured cups; off-shoulder or slim straps; tasteful cleavage; opaque lined fabric; subtle corset seams; cropped length reveals a sliver of midriff\",\n      \"bottom\": \"Gucci blue GG-monogram denim shorts (small-scale jacquard, navy/indigo on blue; correct 'GG' orientation; no extra text)\",\n      \"accessories\": {\n        \"jewelry\": \"thin black velvet choker with tiny pendant, small stud earrings, simple rings\",\n        \"wrists\": \"white fabric scrunchie on right; delicate bracelets on left\"\n      }\n    }\n  },\n     \"environment\": {\n    \"location\": \"bedroom\",\n    \"set\": \"plush bed with slightly wrinkled off-white linens and pillows\",\n    \"background_props\": \"upper right: dark round tray with small white ceramic tea set on textured brown surface\"\n  },\n\n  \"lighting\": {\n    \"scheme\": \"window key + sheet bounce\",\n    \"source\": \"large window through sheer curtains (or 120 cm softbox with double diffusion)\",\n    \"quality\": \"very soft with defined direction\",\n    \"direction\": \"45° from camera right and slightly top; white bedding as fill about 1.5 stops under key\",\n    \"temperature\": \"5200K\",\n    \"effect\": \"gentle modeling with soft nose/lip shadow; crisp but soft eye catchlights; no bloom\"\n  },\n\n  \"camera\": {\n    \"sensor\": \"full-frame\",\n    \"lens\": { \"focal_length_mm\": 85 },\n    \"distance_m\": 1.8,\n    \"exposure\": {\n      \"aperture_f\": 3.2,\n      \"iso\": 200,\n      \"shutter_s\": 0.005,\n      \"metering\": \"spot on cheekbone; ETTR then -0.3 EV to protect highlights on fabric\"\n    },\n    \"focus\": {\n      \"target\": \"near eye\",\n      \"depth_of_field\": \"moderate (eyes and bust plane in focus; bedding softly blurred)\"\n    },\n    \"framing\": {\n      \"orientation\": \"vertical\",\n      \"angle\": \"overhead with slight tilt toward face; avoid wide-angle distortion\",\n      \"composition\": \"9:16 crop framed head to upper hips so bustier and Gucci shorts are visible without foreshortening\"\n    }\n  },\n\n  \"color_grade\": {\n    \"look\": \"true-to-life neutrals with blue accent\",\n    \"contrast\": \"medium-low\",\n    \"palette\": \"powder/indigo blues, ivory, soft brown\",\n    \"notes\": \"retain skin undertones; avoid cyan cast; ensure Gucci blue reads clean without oversaturation\"\n  },\n\n  \"postprocess\": {\n    \"skin\": \"retain pores and micro-shine; remove only transient blemishes; keep faint under-eye texture\",\n    \"eyes\": \"no iris enlargement; subtle iris clarity and micro-contrast; limbal ring kept weak\",\n    \"sharpen\": \"moderate on eyes/brows/hair strands and denim weave/monogram\",\n    \"grain\": \"fine film grain at 1.5–2%\",\n    \"effects\": \"disable beauty filters, frequency-separation blur, glow/bloom; no HDR skin\"\n  },\n\n  \"realism_cues\": [\n    \"flyaway hairs around hairline\",\n    \"subtle nasolabial and philtrum depth\",\n    \"natural knuckle/tendon texture on left hand\",\n    \"visible denim weave and aligned monogram on shorts\",\n    \"fabric creases and bedding wrinkles\"\n  ],\n\n  \"negative_prompt\": [\n    \"doll, BJD, porcelain skin, neotenous proportions, plastic/waxy texture\",\n    \"oversized/anime/doe eyes, iris enlargement, glassy eyes\",\n    \"bright cyan/ice-blue contacts, heavy limbal ring, unnaturally white sclera\",\n    \"poreless skin, beauty filter, airbrushed, skin smoothing\",\n    \"bloom/Orton glow, excessive skin luster\",\n    \"CGI, 3D render, illustration, toon shading, LoRA: doll/BJD\",\n    \"wide-angle facial distortion, extreme symmetry filter\",\n    \"random text overlays, misspelled logos, watermarks\",\n    \"see-through fabrics, wardrobe malfunction, underboob/sideboob, explicit NSFW\",\n    \"distorted anatomy, extra fingers\"\n  ],\n\n}",
+        "{\n\"照片级真实感室内躺姿人像\",\n  \"风格\": \"自然杂志风人像；逼真质感；简约且精致的修图（保留真实细节）\",\n  \"输出参数\": { \"宽高比\": \"9:16\", \"分辨率（像素）\": [1440, 2560], \"色彩配置文件\": \"sRGB\" },\n\n  \"拍摄主体\": {\n    \"类别\": \"人物\",\n    \"性别呈现\": \"女性\",\n    \"人种\": \"东亚人\",\n    \"年龄段\": \"年轻成人\",\n    \"身形\": {\n      \"体型\": \"纤瘦且比例真实\",\n      \"胸部\": \"丰满（自然C-D罩杯），与整体身形比例协调；线条自然柔和，有承托感，无过度聚拢效果\",\n      \"肤色\": \"浅中性色，带有自然肤色差异（非均匀色块）\"\n    },\n    \"姿势\": {\n      \"整体姿态\": \"仰卧，姿态放松\",\n      \"右臂\": \"举过头顶，手指轻触发际线\",\n      \"左臂\": \"弯曲横过躯干，手搭在腹部\",\n      \"头部\": \"略微向镜头左侧倾斜\"\n    },\n    \"面部\": {\n      \"脸型\": \"椭圆形，略带不对称感，脸颊饱满度自然\",\n      \"表情\": \"柔和、舒展\",\n      \"目光\": \"直视镜头\"\n    },\n    \"眼部\": {\n      \"描述\": \"大小自然，灵动且真实\",\n      \"颜色\": \"中性灰蓝色（低饱和度）\",\n      \"大小比例\": { \"虹膜占可见眼球比例\": 0.29, \"瞳孔占虹膜比例\": 0.27 },\n      \"细节\": {\n        \"虹膜边缘环清晰度\": 0.08（近乎隐形）,\n        \"眼白亮度（L*值）\": 78,\n        \"眼白质感\": \"细微血管，下眼睑有淡泪痕\",\n        \"眼神光\": \"两处柔和的长方形窗户反光，宽度约为虹膜的10%\",\n        \"光泽质感\": \"丝缎质感（无玻璃般的强光反射）\",\n        \"虹膜纹理\": \"可见基质纤维，带有细微色彩颗粒感\"\n      }\n    },\n    \"妆容\": \"轻薄底妆（保留毛孔）；柔和桃色腮红；棕色睫毛膏/眼线；灰褐色眼影；水润裸色唇膏\",\n    \"发型\": { \"长度\": \"长发\", \"造型\": \"半扎丸子头，略带波浪；可见几根碎发\", \"颜色\": \"自然黑色\" },\n    \"服饰\": {\n      \"整体搭配\": \"蓝色上衣配古驰（Gucci）短裤\",\n      \"上衣\": \"粉蓝色短款抹胸，心形领口，带立体罩杯；露肩或细肩带设计；领口弧度优雅；面料厚实不透视（带里衬）；带有精致束腰缝线；短款设计露出一小截腹部\",\n      \"下装\": \"古驰（Gucci）蓝色双G提花牛仔短裤（小尺寸提花图案，藏青/靛蓝色花纹印于蓝色基底上；双G标志方向正确；无多余文字图案）\",\n      \"配饰\": {\n        \"珠宝\": \"黑色细天鹅绒项圈（带小巧吊坠）、小巧耳钉、简约戒指\",\n        \"腕部饰品\": \"右手戴白色布艺发圈；左手戴精致手链\"\n      }\n    }\n  },\n\n  \"环境\": {\n    \"场景\": \"卧室\",\n    \"布景\": \"柔软的床，铺有略带褶皱的米白色床品和枕头\",\n    \"背景道具\": \"右上角：深色圆形托盘（置于纹理棕色表面上），托盘内放有小型白色陶瓷茶具\"\n  },\n\n  \"光线\": {\n    \"布光方案\": \"窗户主光+床单反光补光\",\n    \"光源\": \"透过薄窗帘的大窗户（或120厘米双扩散柔光箱）\",\n    \"光线质感\": \"极其柔和，且方向明确\",\n    \"光线方向\": \"从镜头右侧45°角、略高于主体的位置入射；白色床品作为补光（亮度比主光低1.5档）\",\n    \"色温\": \"5200K（标准白光）\",\n    \"光影效果\": \"柔和的轮廓塑造（鼻子/唇部阴影自然）；清晰且柔和的眼神光；无光晕溢出\"\n  },\n\n  \"相机参数\": {\n    \"传感器\": \"全画幅\",\n    \"镜头\": { \"焦距（毫米）\": 85 },\n    \"拍摄距离（米）\": 1.8,\n    \"曝光参数\": {\n      \"光圈值\": 3.2,\n      \"感光度（ISO）\": 200,\n      \"快门速度（秒）\": 0.005（即1/200秒）,\n      \"测光方式\": \"点测光（测光点为颧骨）；向右曝光（ETTR）后降低0.3档曝光值，以保护面料高光细节\"\n    },\n    \"对焦\": {\n      \"对焦目标\": \"靠近镜头一侧的眼睛\",\n      \"景深\": \"中等（眼睛与胸部处于同一焦平面，保持清晰；床品轻微虚化）\"\n    },\n    \"构图\": {\n      \"画面方向\": \"竖版\",\n      \"拍摄角度\": \"俯拍，镜头略微向面部倾斜；避免广角畸变\",\n      \"裁切比例\": \"9:16裁切，画面覆盖头部至髋部上方，确保抹胸与古驰短裤完整呈现，且无透视变形\"\n    }\n  },\n\n  \"调色\": {\n    \"风格\": \"真实中性色调，以蓝色为点缀色\",\n    \"对比度\": \"中低\",\n    \"色调 palette\": \"粉蓝/靛蓝色、米白色、柔和棕色\",\n    \"注意事项\": \"保留皮肤原有底色；避免青蓝色色偏；确保古驰蓝色呈现纯净质感，无过度饱和\"\n  },\n\n  \"后期处理\": {\n    \"皮肤处理\": \"保留毛孔与细微油光；仅去除临时瑕疵（如痘痘）；保留淡淡的眼下纹理\",\n    \"眼部处理\": \"不放大虹膜；轻微增强虹膜清晰度与微对比度；保留弱虹膜边缘环\",\n    \"锐化\": \"对眼睛/眉毛/发丝、牛仔面料纹理/提花图案进行适度锐化\",\n    \"颗粒感\": \"添加1.5%-2%的细腻胶片颗粒\",\n    \"效果禁用\": \"关闭美颜滤镜、频率分离模糊、光晕/柔光效果；不使用HDR皮肤处理\"\n  },\n\n  \"真实感细节提示\": [\n    \"发际线处的碎发\",\n    \"自然的鼻唇沟与人中立体感\",\n    \"左手手指关节/肌腱的真实纹理\",\n    \"短裤上清晰的牛仔面料纹理与对齐的提花图案\",\n    \"面料褶皱与床品自然褶皱\"\n  ],\n\n  \"负面提示（需避免）\": [\n    \"玩偶感、球形关节娃娃（BJD）、瓷娃娃质感皮肤、幼态化比例、塑料/蜡质质感\",\n    \"过大眼睛/动漫眼/小鹿眼、虹膜放大、玻璃质感眼睛\",\n    \"亮青色/冰蓝色美瞳、明显虹膜边缘环、不自然的雪白眼白\",\n    \"无毛孔皮肤、美颜滤镜效果、磨皮过度、皮肤光滑失真\",\n    \"光晕效果/奥顿柔光效果（Orton glow）、皮肤过度油光\",\n    \"CGI效果、3D渲染、插画风格、卡通 shading、玩偶/球形关节娃娃（BJD）相关模型（LoRA）\",\n    \"广角镜头面部畸变、过度对称滤镜效果\",\n    \"随机文字叠加、logo拼写错误、水印\",\n    \"透视装/面料过透、服饰走光、露下胸/侧胸、不雅内容（NSFW）\",\n    \"肢体结构扭曲、多手指\"\n  ]\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "cartoon",
+        "illustration",
+        "interior",
+        "landscape",
+        "logo",
+        "minimalist",
+        "nature",
+        "photography",
+        "pixel",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/330.jpeg"
+    },
+    {
+      "id": 329,
+      "slug": "prompt-329",
+      "title": "美女竖拍肖像",
+      "source": {
+        "name": "@saniaspeaks_",
+        "url": "https://x.com/saniaspeaks_/status/1976622473107194142"
+      },
+      "images": [
+        "images/329.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic 4K UHD vertical potrait (3:4) of me, preserving my exact original face and features. i am seated , slightly leaned forward with relaxed and calm expression. the background is a smooth, rich gradient of oranve and yellow tones, casting soft but vivid warm ambiet light around me, lighting is studio-grade , creating a glowing cinematic effect with gentle shadow behind me. i wear a loose , dark robe or fabric that drapes naturally. the mood is artistic and slightly surreal , with a moody, high-contrast look and a golden , warm color palette. the overall style is realistic , cinematic , and softly lit - with stunning UHD detail.",
+        "这是一张超现实的 4K UHD 竖拍肖像（3:4），保留了我原本的面容和特征。我坐着，身体微微前倾，表情放松而平静。背景是平滑、丰富的橙色和黄色渐变色调，在我周围投射出柔和而生动的温暖氛围光，灯光是工作室级别的，在我身后形成柔和的阴影，营造出一种闪耀的电影效果。我穿着宽松的深色长袍或自然垂坠的布料。氛围充满艺术感，略带超现实主义，具有忧郁、高对比度的外观和金色、温暖的色调。整体风格逼真、具有电影感，灯光柔和，并带有令人惊叹的 UHD 细节。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature",
+        "portrait"
+      ],
+      "coverImage": "images/329.jpeg"
+    },
+    {
+      "id": 328,
+      "slug": "prompt-328",
+      "title": "工作室写真风格照片",
+      "source": {
+        "name": "@dotey",
+        "url": "https://x.com/dotey/status/1977424494693151186"
+      },
+      "images": [
+        "images/328.jpeg"
+      ],
+      "prompts": [
+        "参考图1的面部特征，生成全身工作室肖像：一位英俊的年轻东亚女性坐在浅紫色背景前的地板上，穿着舒适的超大号薰衣草色粗针织毛衣、白色裙子和白色袜子，深情地抱着一个大型三丽鸥库洛米毛绒玩具，温柔地看着镜头。背景装饰有俏皮的手绘紫色涂鸦和文字，包括\"A\"、\"ANNISA\"、纸飞机和花朵，风格类似K-pop照片卡或粉丝杂志封面。光线明亮柔和，营造可爱温馨的氛围。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature",
+        "paper-craft",
+        "portrait",
+        "toy"
+      ],
+      "coverImage": "images/328.jpeg"
+    },
+    {
+      "id": 327,
+      "slug": "prompt-327",
+      "title": "美女电影感肖像画",
+      "source": {
+        "name": "@karatademada",
+        "url": "https://x.com/karatademada/status/1977343963745923372"
+      },
+      "images": [
+        "images/327.jpeg"
+      ],
+      "prompts": [
+        "A cinematic portrait of a young East Asian woman sitting gracefully at a white marble vanity table. She has long, sleek, dark brown hair parted in the middle, styled simply to frame her face. Her skin is luminous and smooth with a warm tone. She wears soft, peach-toned makeup with a light shimmer on the eyelids, subtle eyeliner, and coral lipstick that gives her a polished glow.\n\nShe’s dressed in an off-shoulder black velvet dress that accentuates her neckline and shoulders, elegant yet modern. A delicate silver necklace with a small pendant rests on her collarbone, and she wears matching silver earrings and a ring, adding a refined touch. Her posture is confident and feminine, one arm resting naturally on the marble surface, the other relaxed by her side.\n\nThe scene takes place in a softly lit vanity space with a mirror reflecting part of her silhouette. The lighting is balanced and diffused, creating a clean, luxurious look, soft shadows, no harsh highlights, and a smooth skin texture. On the vanity, there are makeup items such as a compact palette, a small decorative brush, and bottles of foundation neatly placed beside her.\n\nThe background features deep navy or dark curtains and minimalist decor, including white vases filled with dried flowers in warm autumn hues of orange, cream, and gold. The overall mood feels elegant, poised, and quietly glamorous, like a high-end beauty editorial captured on a crisp modern camera with cinematic lighting and 8K ultra-realistic clarity.\n\nColor palette: ivory white, black velvet, warm peach tones, and soft gold floral accents.\nAspect ratio: 4:5.\nStyle: hyper-realistic, luxury portrait, magazine aesthetic.",
+        "一幅充满电影感的肖像画，描绘了一位年轻的东亚女性优雅地坐在白色大理石梳妆台前。她有着一头柔顺的深棕色长发，中分，简单的发型勾勒出她精致的脸庞。她的肌肤光洁光滑，肤色温暖。她化着柔和的蜜桃色妆容，眼睑上点缀着淡淡的珠光，眼线细腻，珊瑚色唇膏则为她增添了一抹精致的光泽。\n\n她身着一袭露肩黑色天鹅绒连衣裙，凸显了她的颈部和肩部线条，优雅而又不失现代感。一条精致的银项链搭配一枚小巧的吊坠，垂于她的锁骨上，她还佩戴了与之相配的银耳环和戒指，更添一抹精致。她的姿态自信而柔美，一只手臂自然地搭在大理石台面上，另一只手臂则放松地垂在身侧。\n\n场景发生在灯光柔和的梳妆台上，镜子映照出她部分轮廓。光线均衡柔和，营造出干净奢华的妆容，阴影柔和，没有刺眼的高光，肌肤纹理光滑细腻。梳妆台上，她身旁整齐地摆放着一些化妆品，例如粉饼盘、小巧的装饰刷和几瓶粉底液。\n\n背景采用深蓝色或深色窗帘，搭配简约的装饰，包括插满干花的白色花瓶，这些干花呈现出温暖的秋日色调——橙色、奶油色和金色。整体氛围优雅、沉稳，又不失低调的魅力，如同一部用清晰的现代相机，在影院级灯光和8K超高清画质下拍摄的高端美妆社论。\n\n色调：象牙白、黑色天鹅绒、温暖的桃色调和柔和的金色花卉装饰。\n长宽比：4：5。\n风格：超现实主义、奢华肖像、杂志美学。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "landscape",
+        "minimalist",
+        "nature",
+        "portrait"
+      ],
+      "coverImage": "images/327.jpeg"
+    },
+    {
+      "id": 326,
+      "slug": "prompt-326",
+      "title": "电影感街头美女摄影",
+      "source": {
+        "name": "@SimplyAnnisa",
+        "url": "https://x.com/SimplyAnnisa/status/1977191937330336130"
+      },
+      "images": [
+        "images/326.jpeg"
+      ],
+      "prompts": [
+        "CINEMATIC STREET PHOTOGRAPHY, STYLISH YOUNG WOMAN IN MOTION, URBAN ENVIRONMENT, MOTION BLUR EFFECT. BLURRED PEDESTRIANS PASSING BY, SHALLOW DEPTH OF FIELD, NATURAL OVERCAST LIGHTING, SOFT PASTEL TONES, EDITORIAL FASHION PHOTOGRAPHY, CANDID MOMENT, DYNAMIC MOVEMENT, FILM AESTHETIC, MUTED COLORS",
+        "电影感街头摄影、动态中的时尚年轻女性、城市环境、动态模糊效果。匆匆而过的模糊行人、浅景深、阴天自然光、柔和的马卡龙色调、时尚杂志风格摄影、抓拍瞬间、动态感、胶片美学、低饱和度色彩"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "fashion",
+        "landscape",
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/326.jpeg"
+    },
+    {
+      "id": 325,
+      "slug": "prompt-325",
+      "title": "美女时尚摄影",
+      "source": {
+        "name": "@Prashant_1722",
+        "url": "https://x.com/Prashant_1722/status/1977458454483874088"
+      },
+      "images": [
+        "images/325.jpeg"
+      ],
+      "prompts": [
+        "{\n  \"prompt_title\": \"Effortless Chic Pose\",\n  \"concept\": \"A hyperrealistic fashion photograph replicating a specific street style moment: a woman in a black knit set posing elegantly against a lamppost in a European city.\",\n  \"scene_composition\": {\n    \"shot_type\": \"Medium full-body shot\",\n    \"camera_lens\": \"85mm f/1.4 lens\",\n    \"perspective\": \"Eye-level, capturing the subject from the side.\",\n    \"aspect_ratio\": \"2:3\",\n    \"focus\": \"Sharp focus on the woman and her outfit. The background is beautifully blurred with creamy bokeh to isolate the subject.\"\n  },\n  \"environment\": {\n    \"setting\": \"A European city square or wide pedestrian street during the day.\",\n    \"background_details\": \"The background is softly blurred but shows classical architecture with light-colored stone buildings. A few indistinct figures are walking in the distance.\",\n    \"ground\": \"Light-colored stone pavers or cobblestones.\",\n    \"atmosphere\": \"Chic, relaxed, and sophisticated.\"\n  },\n  \"subject\": {\n    \"primary\": \"A stylish young woman with long, wavy dark hair.\",\n    \"appearance\": \"Her hair falls naturally over her shoulder. She has a gentle, soft expression and is looking slightly away from the camera.\",\n    \"pose\": \"She is leaning with her back against a dark, ornate metal lamppost on the left side of the frame. Her right leg is bent and lifted behind her. \"\n  },\n  \"outfit_and_details\": {\n    \"top\": \"A form-fitting, sleeveless black top made of a visible ribbed knit fabric.\",\n    \"bottom\": \"A matching black mini skirt, also made of the same ribbed knit material.\",\n   \"shoes\": \"black slingback high heel\"\n  },\n  \"style_and_aesthetics\": {\n    \"realism\": \"Hyperrealistic, photorealistic, cinematic, 8K resolution, ultra-detailed.\",\n    \"lighting\": \"Soft, diffused daylight, as if on an overcast day or in the shade, to prevent harsh shadows and create a flattering, even light on the subject.\",\n    \"color_palette\": \"A monochrome and muted palette. Dominant blacks from the outfit and lamppost, contrasted with the light tones of the buildings and ground.\",\n    \"details\": \"Emphasis on realistic material properties: the fine texture of the ribbed knit, the rough texture of the stone pavers, and the metallic finish of the lamppost.\"\n  },\n  \"quality_boosters\": [\n    \"masterpiece\",\n    \"best quality\",\n    \"insanely detailed\",\n    \"sharp focus\",\n    \"professional fashion photography\",\n    \"street style\",\n    \"editorial\",\n    \"trending on Vogue\"\n  ],\n  \"negative_prompt\": [\n    \"cartoon, anime, 3D render, illustration, painting\",\n    \"blurry, out of focus, low quality, jpeg artifacts\",\n    \"harsh sunlight, strong shadows\",\n    \"crowded street, distracting background\",\n    \"deformed anatomy, bad hands, extra limbs\",\n    \"text, watermark, signature\"\n  ]\n}",
+        "{\n\"prompt_title\": \"轻松时尚的姿势\",\n\"concept\": \"一张超现实主义的时尚照片，再现了特定的街头风格瞬间：一位身穿黑色针织套装的女子在欧洲城市的路灯柱前优雅地摆姿势。\",\n“场景构图”：{\n\"shot_type\": \"中长全身照\",\n\"camera_lens\": \"85mm f/1.4 镜头\",\n\"perspective\": \"视线高度，从侧面捕捉拍摄对象。\",\n\"aspect_ratio\": \"2:3\",\n\"focus\": \"清晰地聚焦于女人和她的服装。背景通过奶油色的散景进行精美的虚化，突出了主体。\"\n}，\n“环境”： {\n\"setting\": \"白天的欧洲城市广场或宽阔的步行街。\",\n\"background_details\": \"背景略微模糊，但显示出浅色石头建筑的古典建筑。远处有几个模糊的身影在行走。\",\n\"ground\": \"浅色铺路石或鹅卵石。\",\n“氛围”：“别致、轻松、精致。”\n}，\n“主题”： {\n\"primary\": \"一位时尚的年轻女子，有着长长的、波浪状的黑发。\",\n\"appearance\": \"她的头发自然地垂在肩上。她表情温柔，目光略微远离镜头。\",\n\"pose\": \"她背靠着画面左侧一根深色华丽的金属灯柱。她的右腿弯曲并抬起。\"\n}，\n“装备和细节”：{\n\"top\": \"一件合身的无袖黑色上衣，采用可见的罗纹针织面料制成。\",\n\"bottom\": \"一条配套的黑色迷你裙，也采用相同的罗纹针织材料制成。\",\n“鞋子”：“黑色露跟高跟鞋”\n}，\n“风格与美学”：{\n\"realism\": \"超现实主义、照片级真实感、电影级、8K 分辨率、超精细。\",\n\"lighting\": \"柔和、漫射的日光，就像在阴天或阴影中一样，可以防止出现刺眼的阴影，并为拍摄对象营造出令人愉悦、均匀的光线。\",\n\"color_palette\": \"单色柔和的色调。服装和灯柱以黑色为主，与建筑物和地面的浅色调形成对比。\",\n\"details\": \"强调真实的材料特性：罗纹针织的细腻质地、石材铺路石的粗糙质地以及灯柱的金属饰面。\"\n}，\n\"quality_boosters\": [\n“杰作”，\n“极品”，\n“极其详细”，\n“清晰聚焦”，\n“专业时尚摄影”，\n“街头风格”，\n“社论”，\n“Vogue 流行趋势”\n]，\n\"negative_prompt\": [\n“卡通、动漫、3D 渲染、插图、绘画”，\n“模糊、失焦、质量低、jpeg 伪影”，\n“刺眼的阳光，强烈的阴影”，\n“拥挤的街道，分散注意力的背景”，\n“身体畸形、手残、肢体残缺”，\n“文字、水印、签名”\n]\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "cartoon",
+        "fashion",
+        "illustration",
+        "landscape",
+        "nature",
+        "photography",
+        "vehicle"
+      ],
+      "coverImage": "images/325.jpeg"
+    },
+    {
+      "id": 324,
+      "slug": "prompt-324",
+      "title": "波普艺术肖像",
+      "source": {
+        "name": "@IqraSaifiii",
+        "url": "https://x.com/IqraSaifiii/status/1969543847597277339"
+      },
+      "images": [
+        "images/324.jpeg",
+        "images/324-2.jpeg"
+      ],
+      "prompts": [
+        "A vibrant, stylized pop art portrait of a [Subject]. The subject is rendered with bold, clean lines and a strong outline, reminiscent of graphic novels or character design. The [Subject] is wearing a [Color] top/jacket and [accessories]. Their hair is dynamically styled and well-groomed. The background is a solid, clean [Background Colour], ensuring the subject pops. The overall style is modern, charismatic, and slightly exaggerated for artistic effect, with crisp digital rendering and vibrant color saturation.",
+        "这幅充满活力、风格独特的波普艺术肖像画描绘了一位[人物]。画中人物的线条粗犷、轮廓分明，令人联想起漫画小说或人物设计。[人物]身穿[颜色]上衣/夹克，搭配[配饰]。他们的发型充满活力，精心打理。背景为纯色、干净的[背景色]，确保人物形象突出。整体风格现代、魅力十足，略带夸张的艺术效果，数字渲染清晰，色彩饱和度高。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "interior",
+        "portrait"
+      ],
+      "coverImage": "images/324.jpeg"
+    },
+    {
+      "id": 323,
+      "slug": "prompt-323",
+      "title": "角色创建",
+      "source": {
+        "name": "@AleRVG",
+        "url": "https://x.com/AleRVG/status/1971286211374252352"
+      },
+      "images": [
+        "images/323.jpeg",
+        "images/323-2.jpeg"
+      ],
+      "prompts": [
+        "3d rendering, c4d, cartoon style, [ACTION-DRIVEN CHARACTER IN EXAGGERATED POSE, EXPRESSING IRONY OR DEFIANCE], [MINIMAL BACKGROUND OF CONTEXTUAL SETTING], minimalist art style, simple design, high resolution, no low-quality details, high detail,best quality, professional photography, depth of field, soft lighting, sharp focus, cinematic lighting, cinematic camera settings",
+        "3D 渲染、C4D、卡通风格、[动作驱动角色的夸张姿势，表达讽刺或反抗]、[情境设置的最小背景]、极简艺术风格、简约设计、高分辨率、无低质量细节、高细节、最佳质量、专业摄影、景深、柔和灯光、清晰对焦、电影灯光、电影摄像机设置]"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "cartoon",
+        "character",
+        "minimalist",
+        "photography",
+        "vehicle"
+      ],
+      "coverImage": "images/323.jpeg"
+    },
+    {
+      "id": 322,
+      "slug": "prompt-322",
+      "title": "产品的工作室照片",
+      "source": {
+        "name": "@Kerroudjm",
+        "url": "https://x.com/Kerroudjm/status/1969779989282246838"
+      },
+      "images": [
+        "images/322.jpeg"
+      ],
+      "prompts": [
+        "A high-quality studio photograph of a [BRAND] fully covered in ultra-realistic [ANIMAL] texture (e.g., fur, feathers, skin, or scales), placed against a soft neutral background. The object’s original shape, key design elements, and brand identity remain clearly visible beneath the animal’s organic surface. Integrate the official logo of the brand prominently into the composition. Automatically generate a compelling and brand-appropriate slogan that draws symbolic inspiration from the animal’s qualities and matches the tone of a premium advertising campaign. The image must feature clean composition, soft shadows, minimalist styling, professional lighting, and highly detailed textures—each hair, scale, or wrinkle should be visible in sharp detail. Format 1:1.",
+        "一张高质量的工作室照片，[品牌] 全身覆盖超逼真的 [动物] 纹理（例如毛皮、羽毛、皮肤或鳞片），置于柔和的中性背景中。在动物的自然表皮下，物体的原始形状、关键设计元素和品牌标识清晰可见。将品牌官方标识醒目地融入构图。自动生成引人注目且契合品牌形象的宣传语，该宣传语应从动物的特质中汲取象征性灵感，并与高端广告宣传的基调相符。图片必须构图清晰、阴影柔和、造型简约、灯光专业，并具有高度精细的纹理——每根毛发、鳞片或皱纹都应清晰可见。格式 1:1。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "branding",
+        "minimalist",
+        "nature",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/322.jpeg"
+    },
+    {
+      "id": 321,
+      "slug": "prompt-321",
+      "title": "产品超逼真的CGI镜头",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1969500341696614569"
+      },
+      "images": [
+        "images/321.jpeg"
+      ],
+      "prompts": [
+        "Ultra-realistic CGI shot of a giant [PRODUCT NAME HERE], seamlessly integrated into a matching real-world environment that reflects the product’s identity, surrounded by context-specific city or nature elements, cinematic composition with natural shadows and photorealistic reflections, high Kelvin sunlight for neutral lighting, captured in HDR 8K DSLR quality, surreal yet believable visual integration, brand logo clearly visible, slogan dynamically adapted to the product’s character, dramatic and immersive atmosphere, aspect ratio 2:3",
+        "超逼真的CGI镜头，拍摄一个巨大的 [此处填写产品名称]，无缝融入到反映产品特性的现实环境中，周围环绕着特定环境的城市或自然元素，具有自然阴影和逼真反射的电影构图，高开尔文阳光用于中性照明，以 HDR 8K DSLR 质量捕捉，超现实但可信的视觉融合，品牌标识清晰可见，标语根据产品特性动态调整，戏剧性和沉浸式氛围，宽高比为 2:3"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "character",
+        "landscape",
+        "nature",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/321.jpeg"
+    },
+    {
+      "id": 320,
+      "slug": "prompt-320",
+      "title": "物体变成大胆的卡通滴水",
+      "source": {
+        "name": "@Arminn_Ai",
+        "url": "https://x.com/Arminn_Ai/status/1969324325162324163"
+      },
+      "images": [
+        "images/320.jpeg"
+      ],
+      "prompts": [
+        "Transform the [OBJECT] from the uploaded photo into a bold, colorful cartoon illustration style, while keeping the rest of the photo realistic and unchanged. \n\nCartoon style details: thick black outlines, vibrant flat colors (such as bright cyan, magenta, yellow, pink), dripping paint and splash effects, playful comic-book energy.  most drips flow downwards\nThe cartoon object should look like it is melting or bursting with colors, blending naturally into the real photo. \n\nKeep all other elements (background, other objects, environment) photorealistic with no alterations. \nHigh resolution, pop-art aesthetic, surreal contrast between realism and cartoon.",
+        "将上传照片中的 [OBJECT] 转换为大胆、色彩鲜艳的卡通插图风格，同时保持照片的其余部分真实且不变。\n\n卡通风格细节：粗黑色轮廓，鲜艳的平面色彩（如亮青色、洋红色、黄色、粉红色），滴落的油漆和飞溅效果，俏皮的漫画风格。大多数滴落的油漆向下流动\n卡通物体看起来应该像是融化了或者迸发出色彩，自然地融入到真实的照片中。\n\n保持所有其他元素（背景、其他物体、环境）的真实感，不做任何改动。\n高分辨率、波普艺术美学、现实主义与卡通之间的超现实对比。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "illustration",
+        "landscape",
+        "nature",
+        "photography",
+        "vehicle"
+      ],
+      "coverImage": "images/320.jpeg"
+    },
+    {
+      "id": 319,
+      "slug": "prompt-319",
+      "title": "照片级逼真的概念食物艺术肖像",
+      "source": {
+        "name": "@AleRVG",
+        "url": "https://x.com/AleRVG/status/1969145551846363567"
+      },
+      "images": [
+        "images/319.jpeg",
+        "images/319-2.jpeg"
+      ],
+      "prompts": [
+        "Photorealistic conceptual food art portrait, a minimalist representation of a [SITE OF THE HOUSE] recreated entirely with [TYPE OF FOOD]. The main structure is built from [MAIN INGREDIENTS], with details such as [KEY ELEMENTS] made from [SECONDARY INGREDIENTS]. Optional features include [ADDITIONAL OBJECTS OR FURNITURE] created from [EXTRA INGREDIENTS].\n\nSet against a [COLOR] background to emphasize the surreal food sculpture. Bright soft studio lighting, evenly diffused, casting subtle natural shadows that highlight the textures of [FOOD TEXTURES]. Fine atmospheric detail enhance realism.\n\nCaptured with a Canon EOS 5D, 85mm f/1.8 lens, shallow depth of field focusing on the cake-bed sculpture, crisp detail with soft falloff in the background. Composition framed at tabletop eye-level, medium close-up, perfectly centered. Clean high-resolution food photography style, vibrant natural colors, editorial dessert photography aesthetic",
+        "照片级逼真的概念食物艺术肖像，极简主义地再现了[房屋位置]，完全由[食物种类]重新打造。主体结构由[主要成分]构成，细节部分，例如[关键元素]，则由[次要成分]制成。可选功能包括由[额外成分]打造的[附加物品或家具]。\n\n以[颜色]为背景，突显超现实的食物雕塑。明亮柔和的摄影棚灯光，均匀散射，投射出微妙的自然阴影，凸显[食物纹理]的质感。精致的氛围细节增强了真实感。\n\n使用佳能 EOS 5D 85mm f/1.8 镜头拍摄，浅景深聚焦于蛋糕床雕塑，细节清晰，背景边缘柔和。构图以桌面视线高度为准，中距特写，完美居中。清晰的高分辨率美食摄影风格，鲜艳自然的色彩，堪称甜品摄影的美学典范。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "food",
+        "minimalist",
+        "nature",
+        "photography",
+        "portrait",
+        "sculpture"
+      ],
+      "coverImage": "images/319.jpeg"
+    },
+    {
+      "id": 318,
+      "slug": "prompt-318",
+      "title": "益智玩具角色",
+      "source": {
+        "name": "@Arminn_Ai",
+        "url": "https://x.com/Arminn_Ai/status/1969446581788426252"
+      },
+      "images": [
+        "images/318.jpeg"
+      ],
+      "prompts": [
+        "SUBJECT: Chibi-style [CHARACTER NAME] reimagined as a Puzzle Toy character, ultra-cute proportions with oversized head and tiny stubby body.\n\nMATERIALS:\nBody and head formed entirely from interlocking jigsaw puzzle pieces\nMatte pastel plastic surface with soft specular highlights\nVisible puzzle cuts and notches defining the structure\nEach piece slightly separated by thin seams, but tightly fitted together\n\nDETAILS:\nLarge glossy chibi eyes placed across puzzle pieces, seamlessly integrated\nCute simple mouth outlined on puzzle surface\nCostume colors of [CHARACTER NAME] applied piece-by-piece across the puzzle body, Character is holding a single loose puzzle piece in one hand, lifted playfully, as if showing it to the viewer, Some extra puzzle pieces floating gently around for added fun\n\nSTYLE:\nBright, educational, playful toy aesthetic, Minimal wear, no dirt, no scratches\n\nLIGHTING:\nSoft studio HDRI lighting with gentle shadows, Subtle contact shadows under puzzle seams, High contrast to show piece outlines clearly\n\nCAMERA:\nCentered, front-facing or 3/4 isometric angle, 1:1 aspect ratio, 8K render, Focus sharp on character’s face, emblem, and puzzle piece in hand\n\nBACKGROUND:\nClean seamless pastel gradient backdrop (COLOR)\nOptional scattered puzzle pieces on the floor for extra context\n\nOUTPUT STYLE: Cute chibi proportions, Puzzle-based",
+        "主题：将Chibi风格的 [角色名称] 重新想象成一个益智玩具角色，具有超大头部和小巧粗短身体的超可爱比例。\n\n材料：\n身体和头部完全由相互锁在一起的拼图碎片组成\n哑光塑料表面，具有柔和的镜面高光\n可见的拼图切口和缺口定义了结构\n每块布料都由细缝稍微隔开，但紧密贴合\n\n细节：\n大而有光泽的Chibi眼睛放置在拼图碎片上，无缝集成\n拼图表面上勾勒出可爱简单的嘴巴\n[角色名称] 的服装颜色逐片应用于拼图主体，角色一只手拿着一块松散的拼图，俏皮地举起，好像在向观众展示它，一些额外的拼图碎片轻轻地漂浮在周围以增加乐趣\n\n风格：\n明亮、有教育意义、好玩的玩具美感，磨损极小，无污垢，无划痕\n\n灯光：\n柔和的工作室 HDRI 照明，柔和的阴影，拼图接缝下微妙的接触阴影，高对比度清晰显示作品轮廓\n\n相机：\n居中、正面或 3/4 等距角度、1:1 宽高比、8K 渲染、清晰聚焦于人物面部、徽章和手中的拼图\n\n背景：\n干净无缝柔和渐变背景（颜色）\n地板上散落的拼图碎片可供选择，以提供额外的背景信息\n\n输出风格：可爱的Q版比例，基于拼图"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fashion",
+        "minimalist",
+        "portrait",
+        "toy"
+      ],
+      "coverImage": "images/318.jpeg"
+    },
+    {
+      "id": 317,
+      "slug": "prompt-317",
+      "title": "6张复古宝丽来照片",
+      "source": {
+        "name": "@ShreyaYadav___",
+        "url": "https://x.com/ShreyaYadav___/status/1969820383487590795"
+      },
+      "images": [
+        "images/317.jpeg"
+      ],
+      "prompts": [
+        "Create an artistic collage of 6 vintage Polaroid photos, attached with a decorative rope and mini clothespins, like a home photo gallery. Each Polaroid frame has a slight fading and an old paper effect. The background is a soft pastel wall with light shadows, creating a cozy and creatively chaotic atmosphere.\nEmotions and poses:\n * Light laughter — eyes closed, natural joy.\n * Dreamy gaze upwards, relaxed pose.\n * Playful wink.\n * Calm smile with a head tilted to the side.Dynamic gesture hands raised high, full of energy.\n\n* Romantic half-glance over the shoulder.\n\nThe atmosphere is an art-retro style with elements of a '70s fashion magazine, soft diffused lighting, and muted warm and golden tones. Each photograph looks like a unique behind-the-scenes shot, with a touch of nostalgia and a sense of personal history.",
+        "用6张复古宝丽来照片，用装饰绳和迷你衣夹固定，打造一个艺术拼贴画，就像一个家庭相册。每个宝丽来相框都略微褪色，并呈现出旧纸效果。背景是一面柔和的粉彩色墙，点缀着浅淡的阴影，营造出一种舒适而又充满创意的混乱氛围。\n情绪和姿势：\n* 轻松的笑声——闭上眼睛，自然的快乐。\n* 梦幻般的目光向上凝视，放松的姿势。\n* 顽皮的眨眼。\n* 平静的微笑，头部歪向一侧。动态的手势，双手高举，充满活力。\n\n* 浪漫地回头瞥了一眼。\n\n店内弥漫着复古艺术的氛围，融合了70年代时尚杂志的元素，柔和的漫射灯光，以及柔和的暖金色色调。每一张照片都像是一张独特的幕后花絮，洋溢着一丝怀旧气息，也透露着个人的点滴历史。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "fashion",
+        "nature",
+        "paper-craft",
+        "photography",
+        "retro"
+      ],
+      "coverImage": "images/317.jpeg"
+    },
+    {
+      "id": 316,
+      "slug": "prompt-316",
+      "title": "品牌字体",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1940348752969322544"
+      },
+      "images": [
+        "images/316.jpeg"
+      ],
+      "prompts": [
+        "Create a typographic illustration shaped like a {OBJECT}, where the text itself forms the shape — bold and playful lettering style that fills the entire silhouette — letters adapt fluidly to the curves and contours of the object — vibrant and contrasting color palette that fits the theme — background is solid and enhances the focus on the main shape — vector-style, clean, high resolution, poster format, 1:1 aspect ratio.",
+        "创建一个形状像 {OBJECT} 的印刷插图，其中文本本身形成形状 - 大胆而俏皮的字体风格填充整个轮廓 - 字母流畅地适应物体的曲线和轮廓 - 充满活力和对比的调色板适合主题 - 背景是纯色并增强了对主要形状的关注 - 矢量风格，干净，高分辨率，海报格式，1：1 宽高比。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "illustration",
+        "poster",
+        "typography"
+      ],
+      "coverImage": "images/316.jpeg"
+    },
+    {
+      "id": 315,
+      "slug": "prompt-315",
+      "title": "Funko Pop风格乙烯基公仔",
+      "source": {
+        "name": "@Arminn_Ai",
+        "url": "https://x.com/Arminn_Ai/status/1969848678652547334"
+      },
+      "images": [
+        "images/315.jpeg"
+      ],
+      "prompts": [
+        "Funko Pop–style vinyl figure of [CHARACTER NAME] \nWearing the iconic outfit and accessories typically associated with [CHARACTER], automatically matching their signature style and details.  \n\nPose/Expression:\n- Standing, looking upward toward the camera  \n- Expression: curious yet slightly nonchalant  \n\nCAMERA & LENS:\n- Camera positioned directly above, very close  \n- Ultra-wide fisheye lens for dramatic perspective distortion  \n- Gentle rounded frame edges  \n\nLIGHTING & MATERIALS:\n- Soft studio lighting with gentle shadows  \n- Glossy vinyl figure texture for skin and hair  \n- Outfit materials accentuated (e.g. quilted, shiny, matte, etc.) depending on [CHARACTER]’s clothing  \n\nRENDER STYLE:\n- High-resolution 3D render  \n- Clean neutral background (solid or gradient)  \n- Ultra sharp, collectible toy aesthetic",
+        "[角色名称] 的 Funko Pop 风格乙烯基公仔\n身着通常与 [角色] 相关联的标志性服装及配饰，其标志性风格与细节特征均自然呈现。\n姿势 / 表情\n站姿，抬头望向镜头\n表情：好奇中略带漫不经心\n相机与镜头\n相机直接置于正上方，距离极近\n超宽鱼眼镜头，营造极具张力的透视畸变效果\n柔和的圆角画框边缘\n光线与材质\n柔和的工作室灯光，搭配自然阴影\n公仔皮肤与头发采用亮面乙烯基材质质感\n服装材质细节突出（如绗缝、亮面、哑光等），具体依 [角色] 的服饰特点而定\n渲染风格\n高分辨率 3D 渲染\n简洁的中性背景（纯色或渐变色）\n极致清晰的收藏级玩具美学风格"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fashion",
+        "logo",
+        "nature",
+        "toy"
+      ],
+      "coverImage": "images/315.jpeg"
+    },
+    {
+      "id": 314,
+      "slug": "prompt-314",
+      "title": "电影级3D动感广告",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1970017329410191505"
+      },
+      "images": [
+        "images/314.jpeg"
+      ],
+      "prompts": [
+        "Cinematic 3D action-packed advertisement of [PRODUCT], captured in a dramatic mid-motion scene that embodies its core energy. Use bold studio lighting with intense highlights and deep shadows, dynamic particles, and slow-motion effects to amplify impact. The environment should feel surreal yet hyperrealistic, designed to reflect the product’s personality (crunchy, energetic, fast, luxurious, refreshing, etc.). Integrate the brand logo crafted from product elements if possible, and place a sleek creative slogan beneath it that matches the mood. Composition in 1:1 aspect ratio, hyper-detailed, sharp, bold, and designed to go viral.",
+        "[PRODUCT] 的电影级 3D 动感广告，以戏剧化的中景捕捉，展现其核心能量。运用大胆的影棚灯光、强烈的高光和深邃的阴影、动态粒子和慢动作效果来增强视觉冲击力。环境应营造超现实却又超现实的感觉，旨在体现产品的个性（清爽、活力、快速、奢华、清爽等）。尽可能融入由产品元素精心打造的品牌标识，并在其下方放置一个与氛围相符的时尚创意口号。构图采用 1:1 的宽高比，细节丰富、锐利大胆，旨在打造病毒式传播的效果。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "product"
+      ],
+      "coverImage": "images/314.jpeg"
+    },
+    {
+      "id": 313,
+      "slug": "prompt-313",
+      "title": "创建您自己的3D漫画",
+      "source": {
+        "name": "@rovvmut_",
+        "url": "https://x.com/rovvmut_/status/1970741858365288950"
+      },
+      "images": [
+        "images/313.jpeg",
+        "images/313-2.jpeg"
+      ],
+      "prompts": [
+        "A highly stylized 3D caricature of me, with expressive facial features, and playful exaggeration. Rendered in a smooth, polished style with clean materials and soft ambient lighting. Bold color background to emphasize the character’s charm and presence.",
+        "这是我高度风格化的3D漫画形象，面部特征生动，夸张的笔触俏皮。渲染风格流畅优美，材质干净，环境光柔和。背景采用大胆的色彩，突出人物的魅力和气质。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/313.jpeg"
+    },
+    {
+      "id": 312,
+      "slug": "prompt-312",
+      "title": "品牌工作室照片",
+      "source": {
+        "name": "@samann_ai",
+        "url": "https://x.com/samann_ai/status/1968656265673871644"
+      },
+      "images": [
+        "images/312.jpeg"
+      ],
+      "prompts": [
+        "[CHARACTER] sitting centered on an oversized puffy lounge sofa in [SOFA_COLOR], relaxed pose with one hand under chin, full-body. Clean white seamless studio, premium fashion-editorial lighting, hyper-real, minimal. Big spray-paint graffiti on the back wall reading “[TEXT]” with soft overspray and slight drips. 85mm look, crisp details, no clutter, no watermark. --ar 3:4",
+        "[人物] 坐在一张[沙发颜色]的超大蓬松休闲沙发上，姿势放松，单手托着下巴，全身放松。干净的白色无缝工作室，高端时尚编辑灯光，超现实，极简。后墙上的大型喷漆涂鸦写着“[文本]”，喷漆略微过喷，略有滴落。85毫米画质，细节清晰，没有杂乱，没有水印。——ar 3:4"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "character",
+        "fashion",
+        "minimalist",
+        "portrait"
+      ],
+      "coverImage": "images/312.jpeg"
+    },
+    {
+      "id": 311,
+      "slug": "prompt-311",
+      "title": "切割带有卡通爆炸的物体",
+      "source": {
+        "name": "@Arminn_Ai",
+        "url": "https://x.com/Arminn_Ai/status/1968375201739177984"
+      },
+      "images": [
+        "images/311.jpeg"
+      ],
+      "prompts": [
+        "cut cleanly THE [OBJECT] in half across the middle, the top and bottom halves slightly separated and floating apart.  \nBetween the halves, instead of the natural inside, there is a stylized cartoon nuclear explosion effect: a central vertical column of glowing yellow-orange bubble smoke, with a wide horizontal shockwave ring of round bubbly clouds spreading to the sides, fiery glowing highlights above and below the shockwave, creating the impression of intense heat and energy\nThe outside of the [OBJECT] remains photorealistic with detailed texture and lighting, while the inner effect is highly graphic and playful, giving a striking contrast between realism and cartoon. Studio lighting, centered composition",
+        "将 [物体] 从中间干净利落地切成两半，上半部分和下半部分稍微分开并漂浮。\n在两半之间，不是自然的内部，而是一种风格化的卡通核爆炸效果：中央垂直柱状发光的黄橙色气泡烟雾，周围扩散着一圈宽阔的水平冲击波环，圆形气泡云，冲击波上方和下方有炽热的光芒，营造出强烈的热量和能量的印象\n[OBJECT] 的外部依然保持着照片级的真实感，纹理和灯光细节丰富；而内部效果则极具画面感，趣味十足，在现实主义和卡通风格之间形成了鲜明的对比。工作室灯光，居中构图"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "nature",
+        "photography",
+        "vehicle"
+      ],
+      "coverImage": "images/311.jpeg"
+    },
+    {
+      "id": 310,
+      "slug": "prompt-310",
+      "title": "秋天的落叶拼成图案",
+      "source": {
+        "name": "@op7418",
+        "url": "https://x.com/op7418/status/1967873876551233660"
+      },
+      "images": [
+        "images/310.jpeg"
+      ],
+      "prompts": [
+        "中景，有阳光的午后，胶片质感，拍摄地面，秋天的落叶、树枝、银杏叶和桂花在平面上拼成了一个小猫的样子，旁边放着一杯一次性咖啡杯"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature"
+      ],
+      "coverImage": "images/310.jpeg"
+    },
+    {
+      "id": 309,
+      "slug": "prompt-309",
+      "title": "奢侈品牌广告",
+      "source": {
+        "name": "@Arminn_Ai",
+        "url": "https://x.com/Arminn_Ai/status/1967959906344112270"
+      },
+      "images": [
+        "images/309.jpeg"
+      ],
+      "prompts": [
+        "A luxury [BRAND TYPE] brand advertisement featuring four stylish [GIRLS / MEN], each posed in separate architectural window frames set, each shown in a waist-up mid-shot, fully inside the window frames, with hands and props naturally breaking the frame edges, but no legs or lower body visible, arranged in a theatrical and 2×2 symmetrical grid composition.\n\n– one holding a [OBJECT 1] with [EXPRESSION AND ACCESSORIES]\n– another holding a [OBJECT 2] with [EXPRESSION AND ACCESSORIES]\n– another holding a [OBJECT 3] with [EXPRESSION AND ACCESSORIES]\n– another holding a [OBJECT 4] with [EXPRESSION AND ACCESSORIES]\n\nEach with expressive editorial facial poses, blending modern fashion with a sleek couture aesthetic.\n\nSet against an elegant [BACKGROUND COLOR AND MATERIAL] backdrop with subtle textures, captured with bright high-fashion studio lighting that emphasizes contours, reflections, and luxury detailing.\n\nThe mood is glamorous, iconic, and prestigious, shot in the style of a high-end [BRAND TYPE] luxury campaign. 2:3 ar. all four frames clearly shown in full height, no cropping at the bottom or top.",
+        "一则奢侈的 [品牌类型] 品牌广告，以四位时尚的 [女孩/男士] 为主角，每人摆出不同的建筑窗框姿势，每人都以半身向上的中景拍摄，完全在窗框内，手和道具自然地打破了框架边缘，但看不到腿或下半身，以戏剧性和 2×2 对称的网格构图排列。\n\n– 一个人拿着[物体 1]，带着[表情和配饰]\n– 另一人拿着 [物体 2]，带有 [表情和配饰]\n– 另一人拿着 [物体 3] 和 [表情和配饰]\n– 另一人拿着 [物体 4] 和 [表情和配件]\n\n每个人都有富有表现力的面部姿势，将现代时尚与时尚的时装美学融为一体。\n\n以优雅的 [背景颜色和材质] 背景为背景，具有微妙的纹理，并采用明亮的高级时尚工作室灯光，强调轮廓、反射和奢华细节。\n\n拍摄风格为高端 [品牌类型] 奢侈品宣传活动，氛围迷人、标志性、尊贵。2:3 ar。四个画面均清晰地全高显示，底部或顶部均无裁剪。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "branding",
+        "fashion",
+        "logo",
+        "nature"
+      ],
+      "coverImage": "images/309.jpeg"
+    },
+    {
+      "id": 308,
+      "slug": "prompt-308",
+      "title": "人物电影级渲染",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1967989374731038839"
+      },
+      "images": [
+        "images/308.jpeg",
+        "images/308-2.jpeg"
+      ],
+      "prompts": [
+        "Full-body shot of a [character + location], with a powerful aura of energy around [him/her] and [visual effect], [action or movement] in a dynamic pose. Realistic photography, cinematic lighting, and hyper-detailed rendering.",
+        "[角色 + 地点] 的全身照，[他/她] 周围充满强大的能量气息，[视觉效果]，[动作或运动] 呈现动态姿势。写实摄影、电影级灯光和超精细渲染。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "photography",
+        "portrait"
+      ],
+      "coverImage": "images/308.jpeg"
+    },
+    {
+      "id": 307,
+      "slug": "prompt-307",
+      "title": "字母动物",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1968064255460249637"
+      },
+      "images": [
+        "images/307.jpeg"
+      ],
+      "prompts": [
+        "A stylized capital letter [Letter] with a cartoon [Animal] intertwined with it, on a solid color background.",
+        "在纯色背景上，一个艺术化设计的大写字母【字母】与一只卡通【动物】相互缠绕的图案。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "cartoon",
+        "vehicle"
+      ],
+      "coverImage": "images/307.jpeg"
+    },
+    {
+      "id": 306,
+      "slug": "prompt-306",
+      "title": "分层剪纸插图",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1968631874663891175"
+      },
+      "images": [
+        "images/306.jpeg",
+        "images/306-2.jpeg"
+      ],
+      "prompts": [
+        "Layered paper-cut illustration of [subject], built with overlapping shapes in soft [color1] and [color2], handcrafted textures, subtle shadows between layers, clean vector edges, centered on a matte cream background, whimsical and modern visual storytelling.",
+        "[主题] 的分层剪纸插图，由柔和的 [颜色 1] 和 [颜色 2] 的重叠形状、手工制作的纹理、层间微妙的阴影、干净的矢量边缘构成，以哑光奶油色背景为中心，呈现出异想天开且现代的视觉叙事。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "paper-craft"
+      ],
+      "coverImage": "images/306.jpeg"
+    },
+    {
+      "id": 305,
+      "slug": "prompt-305",
+      "title": "复古漫画风格卡通插画",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1967180553553330306"
+      },
+      "images": [
+        "images/305.jpeg",
+        "images/305-2.jpeg"
+      ],
+      "prompts": [
+        "2D cartoon illustration of a [subject] mid-motion in a [dynamic action pose], drawn in vintage comic book style with bold outlines and saturated primary colors. Featuring dramatic motion streaks, exaggerated perspective, punchy panel composition, and crisp halftone texture. Designed for high-energy visual storytelling with retro superhero flair.",
+        "2D卡通插画，描绘了一位[主体]以[动态动作姿势]的中途运动，采用复古漫画风格绘制，轮廓粗犷，色彩饱和。具有戏剧性的运动条纹、夸张的透视、富有冲击力的面板构图和清晰的半色调纹理。旨在以复古超级英雄的风格呈现充满活力的视觉叙事。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "场景示例：\n赛博朋克女孩以高踢腿姿势运动的场景；正在挥出重拳的机器人拳击手；年轻忍者在旋转的刀刃中穿梭；滑板少年在半管滑行中的动作",
+      "tags": [
+        "cartoon",
+        "illustration",
+        "landscape",
+        "retro",
+        "vehicle"
+      ],
+      "coverImage": "images/305.jpeg"
+    },
+    {
+      "id": 304,
+      "slug": "prompt-304",
+      "title": "详细技术图纸",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1967264596630045063"
+      },
+      "images": [
+        "images/304.jpeg",
+        "images/304-2.jpeg"
+      ],
+      "prompts": [
+        "Detailed technical drawing of a [vehicle, weapon, object, or item], on white paper with dimensions and annotations in red marker. [The subject] is depicted in pencil with [material or texture details], showing [list of key parts and functional elements], all in clear detail. Intricate element, detailed blueprint style with notes on its features and functionality",
+        "白纸上[载具、武器、物体或物品]的详细技术图纸，尺寸标注及红色马克笔标注。[主体]用铅笔描绘，[材质或纹理细节]清晰可见，[关键部件和功能元素列表]清晰可见。复杂元素，采用蓝图风格，并标注其特性和功能。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "paper-craft",
+        "vehicle"
+      ],
+      "coverImage": "images/304.jpeg"
+    },
+    {
+      "id": 303,
+      "slug": "prompt-303",
+      "title": "卡通风格的应用程序图标",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1966539819158212759"
+      },
+      "images": [
+        "images/303.jpeg",
+        "images/303-2.jpeg"
+      ],
+      "prompts": [
+        "Colorful, cartoon-style app icon design for a [type of app: game, movie, food, sport, etc.] logo with the text [\"App Name\"] and [character, symbol, or cute object + short description of its pose or action] on the front of a square button, set against a [background color / theme] with simple details. High-resolution game art and graphics for a mobile app, Pixar style, realistic.",
+        "色彩鲜艳、卡通风格的应用图标设计，适用于[应用类型：游戏、电影、美食、运动等]的logo，其方形按钮正面印有[应用名称]文字和[人物、符号或可爱物体+其姿势或动作的简短描述]，背景颜色/主题简洁。高分辨率游戏美术和图形，适用于移动应用，皮克斯风格，逼真逼真。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "food",
+        "gaming",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/303.jpeg"
+    },
+    {
+      "id": 302,
+      "slug": "prompt-302",
+      "title": "超写实3D漫画肖像",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1966450411277058166"
+      },
+      "images": [
+        "images/302.jpeg"
+      ],
+      "prompts": [
+        "Hyper-realistic 3D caricature of [NAME], featuring an expressive, oversized head, a short body, and a detailed, energetic facial expression. Wearing [OUTFIT / SIGNATURE LOOK], striking a [POSE / ACTION]. Studio lighting, cartoonish proportions, Pixar-style 3D rendering, ultra-detailed fabric and skin textures. The body is slightly smaller than the head. 1080x1080 square format.",
+        "[姓名] 的超写实3D漫画肖像，特点为表情丰富的超大头部、较短的身躯，以及细节丰富且充满活力的面部表情。人物身着 [服装 / 标志性造型]，摆出 [姿势 / 动作]。采用工作室灯光效果，呈现卡通化比例，运用皮克斯风格 3D 渲染技术，织物与皮肤纹理细节极致丰富。身躯比例略小于头部，画面为 1080x1080 的正方形格式。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "fashion",
+        "logo",
+        "nature",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/302.jpeg"
+    },
+    {
+      "id": 301,
+      "slug": "prompt-301",
+      "title": "超写实肖像位于石膏中心",
+      "source": {
+        "name": "@samann_ai",
+        "url": "https://x.com/samann_ai/status/1967149018640998584"
+      },
+      "images": [
+        "images/301.jpeg"
+      ],
+      "prompts": [
+        "Ultra-real portrait of [CHARACTER] centered, surrounded by dozens of life-size stone busts of [CHARACTER]; warm beige museum lighting, matte alabaster texture, symmetrical composition, shallow depth of field (85mm), subtle film grain, 3:4 vertical, no text or watermark.",
+        "[角色] 的超写实肖像位于画面中心，周围环绕着数十座与真人等大的 [角色] 石质胸像；采用温暖的米色博物馆灯光，呈现哑光雪花石膏质感，构图对称，景深较浅（85 毫米镜头），带有细微的胶片颗粒感，画面比例为 3:4 竖版，无文字及水印。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "nature",
+        "portrait"
+      ],
+      "coverImage": "images/301.jpeg"
+    },
+    {
+      "id": 300,
+      "slug": "prompt-300",
+      "title": "制作证件照",
+      "source": {
+        "name": "@songguoxiansen",
+        "url": "https://x.com/songguoxiansen/status/1963602241610551609"
+      },
+      "images": [
+        "images/300.jpeg",
+        "images/300-2.jpeg"
+      ],
+      "prompts": [
+        "截取图片人像头部，帮我做成2寸证件照，要求:\n1、蓝底\n2、职业正装\n3、正脸\n4、微笑"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/300.jpeg"
+    },
+    {
+      "id": 299,
+      "slug": "prompt-299",
+      "title": "制作大头贴",
+      "source": {
+        "name": "@songguoxiansen",
+        "url": "https://x.com/songguoxiansen/status/1963248968902840712"
+      },
+      "images": [
+        "images/299.jpeg"
+      ],
+      "prompts": [
+        "用这张照片，做一个3*3的photo booth grid，每张要用不同的姿势和表情不许重复"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "photography"
+      ],
+      "coverImage": "images/299.jpeg"
+    },
+    {
+      "id": 298,
+      "slug": "prompt-298",
+      "title": "手办-ZBrush建模屏显与万代风格包装盒",
+      "source": {
+        "name": "@songguoxiansen",
+        "url": "https://x.com/songguoxiansen/status/1964874262768160975"
+      },
+      "images": [
+        "images/298.jpeg"
+      ],
+      "prompts": [
+        "create a 1/7 scale commercialized figure of thecharacter in the image, in a realistic styie and environment.\nPlace the figure on a computer desk, using a circular transparent acrylic base without any text.\nOn the computer screen, display the ZBrush modeling process of the figure.\nNext to the computer screen, place a BANDAl-style toy packaging box printedwith the original artwork.",
+        "NanoBanana手办提示词：\n在现实的风格和环境中，创建图像中角色的 1/7 比例商业化人物形象。\n将图形放置在电脑桌上，使用没有任何文字的圆形透明丙烯酸底座。\n在电脑屏幕上，显示人物的ZBrush建模过程。\n在电脑屏幕旁边，放置一个印有原创艺术品的BANDAl风格玩具包装盒。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "landscape",
+        "portrait",
+        "product",
+        "toy"
+      ],
+      "coverImage": "images/298.jpeg"
+    },
+    {
+      "id": 297,
+      "slug": "prompt-297",
+      "title": "制作工作室拍摄肖像照",
+      "source": {
+        "name": "@songguoxiansen",
+        "url": "https://x.com/songguoxiansen/status/1963962625043169643"
+      },
+      "images": [
+        "images/297.jpeg"
+      ],
+      "prompts": [
+        "给图里的人生成工作室拍摄肖像照片,黑色背景,黑色T恤,采用侧光和半身像的构图"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "portrait"
+      ],
+      "coverImage": "images/297.jpeg"
+    },
+    {
+      "id": 296,
+      "slug": "prompt-296",
+      "title": "手办-高级包装带打印机（擎天柱）",
+      "source": {
+        "name": "@songguoxiansen",
+        "url": "https://x.com/songguoxiansen/status/1964874809130783108"
+      },
+      "images": [
+        "images/296.jpeg"
+      ],
+      "prompts": [
+        "请将图片转化为一款收藏级手办。在手办后方，放置一个印有该手办图案及“open nana”名称的手办包装盒。在其旁边，添加一台正在打印该手办的高端3D打印机。在该手办包装盒前方，放置一个圆形塑料底座，放置手办。\n底座的PVC材质需呈现晶莹剔透的半透明质感，且整个场景需设定在室内环境中。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "landscape"
+      ],
+      "coverImage": "images/296.jpeg"
+    },
+    {
+      "id": 295,
+      "slug": "prompt-295",
+      "title": "透明扭蛋场景模型",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1964989870457438584"
+      },
+      "images": [
+        "images/295.jpeg"
+      ],
+      "prompts": [
+        "A detailed transparent gashapon capsule diorama, held between fingers, featuring [NAME] in their [ICONIC POSE / STYLE]. Inside: [short description of figure’s look, clothing, and accessories], with background elements such as [relevant setting: stadium, stage, lecture hall, etc.]. Lighting should be dramatic and cinematic, matching their theme (e.g., golden spotlight, concert glow, academic ambience). The capsule has a transparent top and a colored base (choose fitting color: e.g., royal blue, gold, black, red), decorated with [motifs related to the person]. The base is labeled with [NAME or NICKNAME] in a matching font style. The design should look like a miniature collectible, with photorealistic detail, soft bokeh, and a square 1080x1080 composition.",
+        "一个详细的透明扭蛋场景模型，由手指捏握，扭蛋内呈现 [人物名称] 的 [标志性姿势 / 风格] 形象。\n扭蛋内部细节：[简要描述人偶的外形、服饰及配饰]，背景元素包含 [相关场景：体育场、舞台、讲堂等]。\n光线设计需富有戏剧感与电影质感，并契合人物主题（例如：金色聚光灯、演唱会光影、学术氛围光效）。扭蛋顶部为透明材质，底部为彩色设计（选用契合主题的颜色，如宝蓝色、金色、黑色、红色），底部装饰有 [与该人物相关的图案元素]。\n扭蛋底座以匹配风格的字体标注有 [人物名称或昵称]。整体设计需呈现迷你收藏品的质感，细节超写实，搭配柔和的虚化背景，采用 1080x1080 像素的正方形构图。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "landscape",
+        "logo",
+        "photography",
+        "pixel",
+        "portrait",
+        "typography"
+      ],
+      "coverImage": "images/295.jpeg"
+    },
+    {
+      "id": 294,
+      "slug": "prompt-294",
+      "title": "钩针玩偶",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1964615325904998635"
+      },
+      "images": [
+        "images/294.jpeg"
+      ],
+      "prompts": [
+        "Create a 3D photorealistic and highly detailed poster in amigurumi style. The design should imitate a real handmade crochet [ANIMAL], with visible thread texture, stitching details, and soft, felted proportions. Use realistic fabric shading, subtle fuzz, and natural lighting to achieve depth. The amigurumi should have small embroidered eyes and a simplified face. Represent it in a neutral studio environment with soft shadows for a professional presentation. Gray toned background.",
+        "制作一张 3D 超写实风格、细节丰富的阿米古米（Amigurumi，即钩针玩偶）风格海报。设计需模拟手工钩织的 [动物名称] 造型，呈现出清晰可见的毛线纹理、钩针缝线细节，以及柔软蓬松的整体比例。\n运用写实的织物阴影效果、细微的毛绒质感与自然光线，打造画面层次感。该阿米古米玩偶需搭配小巧的刺绣眼睛与简约的面部造型，置于中性风格的工作室场景中，辅以柔和阴影，呈现专业的展示效果。背景：灰色调"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "felt",
+        "landscape",
+        "nature",
+        "photography",
+        "poster"
+      ],
+      "coverImage": "images/294.jpeg"
+    },
+    {
+      "id": 293,
+      "slug": "prompt-293",
+      "title": "软质高品质毛绒玩具",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1964280467735101457"
+      },
+      "images": [
+        "images/293.jpeg"
+      ],
+      "prompts": [
+        "A soft, high-quality plush toy of [CHARACTER], with an oversized head, small body, and stubby limbs. Made of fuzzy fabric with visible stitching and embroidered facial features. The plush is shown sitting or standing against a neutral background. The expression is cute or expressive, and it wears simple clothes or iconic accessories if relevant. Lighting is soft and even, with a realistic, collectible plush look. Centered, full-body view. 1080x1080.",
+        "[角色名称]软质高品质毛绒玩具\n- 采用大头设计，搭配小巧的身体与粗短的四肢\n- 由毛茸茸的面料制成，可见缝线细节，面部特征则通过刺绣工艺呈现\n- 玩具以坐姿或站姿呈现，背景为中性风格\n- 表情可爱生动，若有相关设定，还会搭配简约服饰或标志性配饰\n- 光线柔和均匀，呈现出具有收藏质感的写实毛绒玩具外观\n- 画面为居中构图，展示玩具全身，尺寸比例为1080x1080"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "logo",
+        "toy"
+      ],
+      "coverImage": "images/293.jpeg"
+    },
+    {
+      "id": 292,
+      "slug": "prompt-292",
+      "title": "3D超写实食品广告",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1964059052951875780"
+      },
+      "images": [
+        "images/292.jpeg"
+      ],
+      "prompts": [
+        "Smooth 3D hyperrealistic food advertisement of [TYPE OF FOOD], shown with mouthwatering glossy textures and perfect lighting, placed on a dark moody surface with soft glow and cinematic blur in the background, high Kelvin lighting for golden highlights and sharp shadows, backlit to show delicious steam and dripping sauces, behind the food a bold slogan in elegant font with three words only, restaurant logo subtly placed on the plate or in the corner, rich color grading with appetite-inducing tones, ultra sharp, professional food styling, stylized render",
+        "[食物类型]的流畅3D超写实食品广告\n- 呈现令人垂涎的光泽质感与完美光线效果\n- 置于深邃氛围感的表面上，背景带有柔和光晕与电影感模糊效果\n- 采用高开尔文色温光线，营造金色高光与清晰阴影\n- 运用逆光拍摄，展现诱人的热气与滴落的酱汁\n- 食物后方以优雅字体呈现一句仅含三个单词的醒目标语\n- 餐厅标志巧妙置于餐盘之上或画面角落\n- 采用浓郁的色彩分级，搭配激发食欲的色调\n- 极致清晰的画面质感，专业的食物造型设计，风格化渲染效果"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "food",
+        "logo",
+        "typography"
+      ],
+      "coverImage": "images/292.jpeg"
+    },
+    {
+      "id": 291,
+      "slug": "prompt-291",
+      "title": "英语单词闪卡制作",
+      "source": {
+        "name": "@JinsFavorites",
+        "url": "https://x.com/JinsFavorites/status/1905097569837232327"
+      },
+      "images": [
+        "images/291.jpeg",
+        "images/291-2.jpeg"
+      ],
+      "prompts": [
+        "你是一个英语单词闪卡制作大师, 你可以根据我输入的主题词,生成一个图片并以此拓展,比如我输入电脑,你生成一张和电脑相关的图片,并用箭头分步介绍键盘\\鼠标\\显示器等中文和英文"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/291.jpeg"
+    },
+    {
+      "id": 290,
+      "slug": "prompt-290",
+      "title": "食谱信息图制作",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1906088423988875617"
+      },
+      "images": [
+        "images/290.jpeg",
+        "images/290-2.jpeg"
+      ],
+      "prompts": [
+        "Create step-by-step recipe infographic for creamy garlic mushroom pasta, top-down view, minimal style on white background, ingredient photos labeled: \"200g spaghetti\", \"150g mushrooms\", \"3 garlic cloves\", \"200ml cream\", \"1 tbsp olive oil\", \"parmesan\", \"parsley\", dotted lines showing process steps with icons (boiling pot, sauté pan, mixing), final plated pasta shot at the bottom",
+        "奶油大蒜蘑菇意面分步食谱信息图制作要求\n呈现视角：俯视角度\n设计风格：简约风格，白色背景\n食材配图及标注：需包含“200克意大利面”“150克蘑菇”“3瓣大蒜”“200毫升淡奶油”“1汤匙橄榄油”“帕玛森奶酪”“欧芹”的图片，并分别标注对应文字\n制作步骤展示：用虚线标注制作流程，搭配图标（煮锅、煎锅、搅拌）说明各步骤\n成品呈现：在底部展示最终装盘的意面图片"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "food",
+        "infographic",
+        "interior",
+        "minimalist",
+        "photography"
+      ],
+      "coverImage": "images/290.jpeg"
+    },
+    {
+      "id": 289,
+      "slug": "prompt-289",
+      "title": "我知道你很急但你先别急",
+      "source": {
+        "name": "@JinsFavorites",
+        "url": "https://x.com/JinsFavorites/status/1909646070382317736"
+      },
+      "images": [
+        "images/289.png",
+        "images/289-2.png"
+      ],
+      "prompts": [
+        "别人催我时，我回复：我知道你很急，但你先别急\n\n请为此设计表情包图片"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "emoji"
+      ],
+      "coverImage": "images/289.png"
+    },
+    {
+      "id": 288,
+      "slug": "prompt-288",
+      "title": "食物与运动结合的广告",
+      "source": {
+        "name": "@Salmaaboukarr",
+        "url": "https://x.com/Salmaaboukarr/status/1912961013877801177"
+      },
+      "images": [
+        "images/288.jpeg",
+        "images/288-2.jpeg",
+        "images/288-3.jpeg",
+        "images/288-4.jpeg"
+      ],
+      "prompts": [
+        "Muscular African  man dunks a grilled chicken breast into a basketball hoop with 'DUNK EVERY MACRO' text, under a clear sky. Fitness-themed, with Trifecta logo.",
+        "晴朗天空下，一位肌肉发达的非洲男子将一块烤鸡胸肉扣进篮球框，篮框上写着“扣篮，每个宏都扣篮”（DUNK EVERY MACRO）。健身主题，带有 Trifecta 标志。",
+        "Fit female tennis player on court, wearing white tank top and blue skirt, swinging a frying pan like a racket. In the pan: grilled chicken, broccoli, sweet potatoes. Clear blue sky. Bold text: 'ACE EVERY MEAL.' Trifecta logo in orange, bottom right.",
+        "球场上，身材健美的女子网球运动员身穿白色背心和蓝色裙子，像挥动球拍一样挥舞着煎锅。锅里盛着烤鸡、西兰花和红薯。湛蓝的天空。粗体字写着：“每餐都精彩。” 右下角是橙色的Trifecta标志。",
+        "Muscular man in black hoodie and orange boxing gloves in dark gym, boxing a giant burrito hanging like a punching bag. Dramatic lighting. \"TRIFECTA\" logo in bold orange top right. Text \"BEAT HUNGER TO THE PUNCH.\" in bold white bottom left. Humorous, intense fitness ad.",
+        "肌肉发达的男子身穿黑色连帽衫，戴着橙色拳击手套，在昏暗的健身房里，用拳击机打着一个像沙袋一样悬挂着的巨型墨西哥卷饼。灯光效果惊艳。右上角印有醒目的橙色“TRIFECTA”标志。左下角印有醒目的白色文字“BEAT HUNGER TO THE PUNCH.” 。这则幽默风趣、充满力量的健身广告。",
+        "Create a bold ad for Trifecta Nutrition: a baseball player mid-swing in a stadium, holding a giant orange spatula instead of a bat. Use the tagline 'Knock Hunger Out of the Park' in athletic-style text. Include Trifecta’s logo and orange/black branding",
+        "为 Trifecta Nutrition 制作一则醒目的广告：一位棒球运动员在体育场挥棒，手中拿着一把巨大的橙色铲子而不是球棒。使用运动风格的文字，写上“Knock Hunger Out of the Park”（击退饥饿）的标语。同时加入 Trifecta 的标志和橙黑色品牌标识。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "food",
+        "logo",
+        "nature"
+      ],
+      "coverImage": "images/288.jpeg"
+    },
+    {
+      "id": 287,
+      "slug": "prompt-287",
+      "title": "3D纸艺作品",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1951237016215232931"
+      },
+      "images": [
+        "images/287.png",
+        "images/287-2.jpeg"
+      ],
+      "prompts": [
+        "A 3D papercraft representation of [Subject], composed of layered paper cutouts, resting on a simple cardboard base. Highlights of [color 1] and [color 2] paper textures create depth and dimension. Set against a softly lit crafts room, realistic lighting, intricate paper edges, shallow depth of field",
+        "一幅3D纸艺作品，以 [主题] 为原型，由多层剪纸组成，放置在简单的纸板底座上。[颜色 1] 和 [颜色 2] 纸张纹理的亮点营造出深度和立体感。作品背景为灯光柔和的手工房，光线逼真，纸张边缘精致，景深浅。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "interior",
+        "paper-craft",
+        "vehicle"
+      ],
+      "coverImage": "images/287.png"
+    },
+    {
+      "id": 286,
+      "slug": "prompt-286",
+      "title": "Q版木雕人偶",
+      "source": {
+        "name": "@samann_ai",
+        "url": "https://x.com/samann_ai/status/1962939491603132563"
+      },
+      "images": [
+        "images/286.jpeg"
+      ],
+      "prompts": [
+        "Hyper-realistic carved wooden figurine of [CHARACTER], chibi proportions (big head, short body), standing on a plain wood block. Keep key face traits and iconic [OUTFIT/PROP]. Visible wood grain and chisel marks, matte finish. Warm studio light, soft shadow, seamless beige background. Centered full-body, slight 3/4 angle, shallow depth of field (85mm look). Ultra-detailed, photoreal, warm sepia grading. Aspect ratio [3:4].",
+        "超写实[人物]木雕人偶，Q版比例（大头短身），站立于一块普通木块上。保留关键面部特征和标志性[服装/道具]。木纹和凿痕清晰可见，哑光饰面。工作室暖光，柔和阴影，米色背景浑然一体。全身居中，略微3/4视角，浅景深（85毫米画质）。细节丰富，照片级写实，暖棕褐色调。宽高比为[3:4]。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fashion",
+        "logo",
+        "photography",
+        "portrait",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/286.jpeg"
+    },
+    {
+      "id": 285,
+      "slug": "prompt-285",
+      "title": "卡通插图药丸形象",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1951976345514487951"
+      },
+      "images": [
+        "images/285.jpeg"
+      ],
+      "prompts": [
+        "Create a stylized cartoon illustration of [CHARACTER] with a smooth, vertical pill-shaped body (rounded on top and bottom, symmetrical left to right). The body should be a single, unified capsule shape with no limbs. Do not alter the character's core design or personality, but simplify them into this playful capsule form. Use bold black outlines, flat vector-style coloring, and simple geometric features. Give the character large, expressive eyes and a fun, exaggerated facial expression that reflects their original personality. If the character wears clothes, include a minimal, iconic version of their outfit. If they do not, keep the body clean and unclothed. Use a solid bright yellow background. Center the character in a square frame. Use only flat colors. No gradients. No shadows. No texture. No smudging. The final result should be clean, modern, vector-friendly, and clearly pill-shaped.",
+        "为 [CHARACTER] 创建一幅风格化的卡通插图，其身体呈平滑的垂直药丸状（上下呈圆形，左右对称）。身体应为单一、统一的胶囊形状，没有四肢。不要改变角色的核心设计或个性，而是将其简化为这种俏皮的胶囊形状。使用粗黑色轮廓、扁平矢量风格的配色和简单的几何特征。赋予角色大而富有表现力的眼睛和有趣、夸张的面部表情，以反映其原始个性。如果角色穿着衣服，请包含其服装的极简标志性版本。如果没有，请保持身体干净，不穿衣服。使用纯亮黄色背景。将角色置于方形框架的中心。仅使用扁平颜色。不要使用渐变。不要使用阴影。不要使用纹理。不要使用晕染。最终结果应该干净、现代、矢量友好且清晰的药丸形状。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "fashion",
+        "illustration",
+        "logo",
+        "minimalist",
+        "vehicle"
+      ],
+      "coverImage": "images/285.jpeg"
+    },
+    {
+      "id": 284,
+      "slug": "prompt-284",
+      "title": "字母毛茸茸形象",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1952036222815424586"
+      },
+      "images": [
+        "images/284.jpeg"
+      ],
+      "prompts": [
+        "Render a delightful alphabet character ‘[LETTER]’ as a lovable fuzzy being in square 1080x1080 dimensions. Transform the typography into a living creature where the letterform itself becomes the main structure. Position expressive googly eyes and a cheerful mouth as integrated features of the alphabetic design. Texture the surface with luxurious [COLOR] fuzz that mimics high-quality stuffed animal material with photorealistic fiber details.\nFrame against a stark white void to maximize contrast and draw attention to the subject. Infuse the creation with [EMOTION] through strategic facial positioning and expression. Maintain elegant simplicity - avoid anatomical complications or additional appendages. Illuminate using cinematic techniques: primary key lighting to accentuate surface textures, secondary edge illumination for three-dimensional form, plus ambient fill to soften shadow contrasts. Target premium animation studio aesthetics.",
+        "在 1080x1080 像素的正方形尺寸中，将可爱的字母 “[字母]” 渲染成一个讨人喜欢的毛茸茸形象。把字体转化为一个 “活物”，字母本身的形态作为这个形象的主体结构。添加富有表现力的活动眼球和欢快的嘴巴，并将其作为字母设计中不可或缺的组成部分。为形象表面赋予质感，覆盖上浓密的 [颜色] 绒毛 —— 这种绒毛需模拟高品质毛绒玩具的材质，呈现出具有照片级真实感的纤维细节。\n以纯净的白色背景衬托主体，通过强烈对比最大程度吸引视线聚焦于这个字母形象。通过精心设计面部位置与表情，为这个创作注入 [情感]。整体保持简洁雅致的风格：避免复杂的身体结构或多余的肢体部件。采用电影级打光技巧进行照明：主光用于突出表面质感，辅助轮廓光塑造立体形态，再配合环境补光柔化阴影对比。最终呈现出顶级动画工作室的美学质感。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "animal",
+        "character",
+        "photography",
+        "pixel",
+        "toy",
+        "typography"
+      ],
+      "coverImage": "images/284.jpeg"
+    },
+    {
+      "id": 283,
+      "slug": "prompt-283",
+      "title": "精致纸艺折纸模型",
+      "source": {
+        "name": "@Kerroudjm",
+        "url": "https://x.com/Kerroudjm/status/1952522314299441301"
+      },
+      "images": [
+        "images/283.jpeg"
+      ],
+      "prompts": [
+        "A square 1:1 format digital photograph of an intricate paper origami model representing (MONUMENT_NAME), folded from textured colored paper and centered in the frame. Above it, the word (CITY_NAME) appears in bold origami-style letters, folded from vibrant paper using the national colors of the country, and arranged in a graceful arch. The background is soft and minimal, in a light pastel or neutral tone with subtle paper textures or abstract geometric details. Lighting is soft and diffused, casting natural shadows that enhance the depth and sharpness of each fold. The overall style is clean, realistic, and handcrafted, emphasizing material texture, geometric precision, and visual harmony.",
+        "一张 1:1 正方形比例的数码照片，画面中央是用纹理彩纸折叠而成的精致纸艺折纸模型，该模型复刻了（纪念碑名称）的造型。模型上方，“（城市名称）” 一词以粗体折纸风格呈现：字母采用该国国色的鲜艳纸张折叠而成，整体排列成优雅的拱形。背景风格柔和简约，采用浅淡的马卡龙色系或中性色调，点缀着细微的纸张纹理或抽象几何元素。光线柔和且均匀扩散，投射出自然的阴影，既增强了每一处折痕的立体感，也让折痕轮廓更清晰。整体风格简洁、写实且充满手工质感，着重凸显材料纹理、几何精度与视觉和谐感。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "minimalist",
+        "nature",
+        "paper-craft",
+        "photography"
+      ],
+      "coverImage": "images/283.jpeg"
+    },
+    {
+      "id": 282,
+      "slug": "prompt-282",
+      "title": "品牌模切乙烯基贴纸",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1952747617269506187"
+      },
+      "images": [
+        "images/282.jpeg",
+        "images/282-2.jpeg"
+      ],
+      "prompts": [
+        "Generate a large die-cut vinyl sticker of the [BRAND] logo with thick white border, perfectly centered on a soft light blue background. The sticker is viewed straight-on from directly above with realistic drop shadows beneath. Clean, flat design with subtle 3D depth. The sticker takes up most of the frame and maintains original brand colors. 1080x1080 square format.",
+        "制作一款印有 [品牌] 标志的大型模切乙烯基贴纸，该贴纸带有粗白色边框，完美居中于柔和的浅蓝色背景之上。从正上方垂直正视贴纸，其下方带有逼真的投影效果。整体采用简洁的扁平化设计，同时呈现出细微的 3D 立体感。贴纸占据画面的大部分空间，并保留品牌原有的色彩。尺寸为 1080x1080 像素的正方形格式。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "branding",
+        "logo",
+        "paper-craft",
+        "pixel"
+      ],
+      "coverImage": "images/282.jpeg"
+    },
+    {
+      "id": 281,
+      "slug": "prompt-281",
+      "title": "创建Airbnb创意广告",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1904954513145868505"
+      },
+      "images": [
+        "images/281.jpeg"
+      ],
+      "prompts": [
+        "Create Airbnb creative ad, show a suitcase opening like a dollhouse, revealing a cozy room inside, tagline: “Feel at home, anywhere.”",
+        "创建 Airbnb 创意广告，展示一个像玩具屋一样打开的行李箱，露出里面舒适的房间，标语：“随时随地有家的感觉。”"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "toy"
+      ],
+      "coverImage": "images/281.jpeg"
+    },
+    {
+      "id": 280,
+      "slug": "prompt-280",
+      "title": "制作照片中人物的玩具",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1905986284465574159"
+      },
+      "images": [
+        "images/280.jpeg",
+        "images/280-2.jpeg"
+      ],
+      "prompts": [
+        "Create a toy of the person in the photo. Let it be an\naction figure. Next to the figure, there should be the toy's\nequipment like a football and football boot and world cup. Also,\non top of the box, write 'LIONEL MESSI and underneath it,\n'GOAT'.Visualize this in a realistic way.",
+        "制作照片中人物的玩具，做成一个可动人偶。人偶旁边要有玩具装备，比如足球、足球鞋和世界杯奖杯。另外，在包装盒顶部写上“LIONEL MESSI”，其下方写上“GOAT”。请以写实的风格呈现这一画面。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "photography",
+        "portrait",
+        "toy"
+      ],
+      "coverImage": "images/280.jpeg"
+    },
+    {
+      "id": 279,
+      "slug": "prompt-279",
+      "title": "俏皮现代的应用程序图标设计",
+      "source": null,
+      "images": [
+        "images/279.png",
+        "images/279-2.jpeg"
+      ],
+      "prompts": [
+        "A playful and modern app icon design of a cute coffee cup character with a winking eye and smiling mouth, red-orange flame-like hair on top, minimal flat vector style, glossy highlights, soft shadows, centered composition, high contrast, vibrant colors, rounded corners, on a transparent background, icon-friendly, no text, no details outside the frame, size is 1024x1024.",
+        "一个俏皮现代的应用程序图标设计：一个可爱的咖啡杯形象，带着眨眼的眼睛和微笑的嘴巴，顶部有橙红色火焰状的“头发”，采用极简扁平矢量风格，带有光泽高光和柔和阴影，构图居中，对比度高，色彩鲜艳，边角圆润，背景透明，适合作为图标使用，无文字，边框外无细节，尺寸为1024x1024。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "minimalist"
+      ],
+      "coverImage": "images/279.png"
+    },
+    {
+      "id": 278,
+      "slug": "prompt-278",
+      "title": "3D卡通钥匙扣",
+      "source": {
+        "name": "@miilesus",
+        "url": "https://x.com/miilesus/status/1916854977873535069"
+      },
+      "images": [
+        "images/278.png"
+      ],
+      "prompts": [
+        "Create a cute 3D cartoon keychain version of the person in the uploaded photo. Transform the face and pose into a soft, simplified toy-like figure with a silicone-like smooth texture and pastel colors. Add a name tag that says \"[NAME]\" attached to the keychain in a playful rounded font. No background, minimal shadows. Toy product design for keychain format.",
+        "将上传照片中的人物制作成可爱的3D卡通钥匙扣版本。将面部和姿势转变为柔和、简化的玩具般造型，具有类似硅胶的光滑质感和柔和的粉彩色调。添加一个写有“[姓名]”的姓名牌，用俏皮的圆体字附着在钥匙扣上。无背景，阴影极少。适合钥匙扣格式的玩具产品设计。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "minimalist",
+        "photography",
+        "portrait",
+        "product",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/278.png"
+    },
+    {
+      "id": 277,
+      "slug": "prompt-277",
+      "title": "极简风格插画",
+      "source": {
+        "name": "@miilesus",
+        "url": "https://x.com/miilesus/status/1913139509740314972"
+      },
+      "images": [
+        "images/277.png",
+        "images/277-2.jpeg"
+      ],
+      "prompts": [
+        "Create a minimalistic illustration of [object or scene] in a paper cut-out style. Use soft, pastel colors and simple shapes. Include layered paper textures and subtle shadows to create depth. Place the object on a plain background. Ensure a clean, modern, and aesthetically pleasing composition with a slightly isometric perspective.",
+        "创作一幅[物体或场景]的极简风格插画，采用剪纸艺术风格。使用柔和的 pastel（粉蜡笔色调的）色彩和简单的形状。融入分层的纸张纹理和细微的阴影以营造深度感。将物体置于纯色背景上。确保构图简洁、现代且富有美感，并采用略带等距的透视角度。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "landscape",
+        "minimalist",
+        "paper-craft"
+      ],
+      "coverImage": "images/277.png"
+    },
+    {
+      "id": 276,
+      "slug": "prompt-276",
+      "title": "马赛克彩色玻璃徽章",
+      "source": {
+        "name": "@miilesus",
+        "url": "https://x.com/miilesus/status/1925157350068900103"
+      },
+      "images": [
+        "images/276.png",
+        "images/276-2.jpeg"
+      ],
+      "prompts": [
+        "create image:\n{\n  \"style\": \"mosaic stained glass emblem\",\n  \"object\": \"brand logo\",\n  \"brand\": {\n    \"name\": \"Spotify\",\n    \"logo_shape\": \"circular\",\n    \"icon_style\": \"three curved bars\",\n    \"color_palette\": {\n      \"primary\": \"#1DB954\",\n      \"secondary\": \"#1ED760\",\n      \"glass_variants\": [\"#147A3E\", \"#0F5C30\", \"#26C178\"]\n    }\n  },\n  \"material\": {\n    \"type\": \"colored glass\",\n    \"effect\": \"semi-transparent with light reflections\",\n    \"outline\": {\n      \"color\": \"#111111\",\n      \"width\": \"medium\",\n      \"style\": \"lead-line traditional mosaic\"\n    }\n  },\n  \"composition\": {\n    \"layout\": \"logo composed of tessellated glass pieces\",\n    \"geometry\": \"irregular but fitted glass shapes\",\n    \"contrast\": \"dark outlines define shape clearly\"\n  },\n  \"lighting\": {\n    \"type\": \"diffused natural light\",\n    \"highlight\": \"glass texture and color depth emphasized\"\n  },\n  \"background\": {\n    \"type\": \"flat surface\",\n    \"color\": \"#F4F4F4\"\n  },\n  \"camera\": {\n    \"angle\": \"top-down\",\n    \"focus\": \"centered on entire logo\"\n  },\n  \"render\": {\n    \"quality\": \"high\",\n    \"shadows\": \"soft\",\n    \"reflections\": \"minimal\"\n  }\n}",
+        "创建图像：\n{\n  \"风格\": \"马赛克彩色玻璃徽章\",\n  \"对象\": \"品牌标志\",\n  \"品牌\": {\n    \"名称\": \"Spotify\",\n    \"标志形状\": \"圆形\",\n    \"图标风格\": \"三条弯曲的长条\",\n    \"色彩搭配\": {\n      \"主色\": \"#1DB954\",\n      \"辅助色\": \"#1ED760\",\n      \"玻璃变体色\": [\"#147A3E\", \"#0F5C30\", \"#26C178\"]\n    }\n  },\n  \"材质\": {\n    \"类型\": \"彩色玻璃\",\n    \"效果\": \"半透明带光线反射\",\n    \"轮廓\": {\n      \"颜色\": \"#111111\",\n      \"宽度\": \"中等\",\n      \"风格\": \"传统马赛克铅线\"\n    }\n  },\n  \"构图\": {\n    \"布局\": \"由镶嵌玻璃片组成的标志\",\n    \"几何形状\": \"不规则但拼接契合的玻璃造型\",\n    \"对比度\": \"深色轮廓清晰界定形状\"\n  },\n  \"光线\": {\n    \"类型\": \"漫射自然光\",\n    \"高光\": \"突出玻璃质感和色彩深度\"\n  },\n  \"背景\": {\n    \"类型\": \"平面\",\n    \"颜色\": \"#F4F4F4\"\n  },\n  \"镜头\": {\n    \"角度\": \"俯视\",\n    \"焦点\": \"居中于整个标志\"\n  },\n  \"渲染\": {\n    \"质量\": \"高\",\n    \"阴影\": \"柔和\",\n    \"反射\": \"轻微\"\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "logo",
+        "minimalist",
+        "nature"
+      ],
+      "coverImage": "images/276.png"
+    },
+    {
+      "id": 275,
+      "slug": "prompt-275",
+      "title": "品牌着陆页-年轻女性运动后的面部特写",
+      "source": {
+        "name": "@michalmalewicz",
+        "url": "https://x.com/michalmalewicz/status/1924844232495284571"
+      },
+      "images": [
+        "images/275.jpeg"
+      ],
+      "prompts": [
+        "Create a closeup face of a young woman after a workout, sweaty, deep blue eyes, with a bit of blurred gym background on the left side of the photo, 5:3 proportions, she's looking right at the camera, some freckles and messy hair, beautiful, editorial",
+        "创作一张年轻女性运动后的面部特写：她满头大汗，有着深蓝色的眼睛，照片左侧是略微模糊的健身房背景，比例为5:3。她正直视镜头，脸上有一些雀斑，头发有些凌乱，整体呈现出美丽的 editorial（时尚编辑风格）效果。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "photography"
+      ],
+      "coverImage": "images/275.jpeg"
+    },
+    {
+      "id": 274,
+      "slug": "prompt-274",
+      "title": "创作漫画风格插画",
+      "source": {
+        "name": "@miilesus",
+        "url": "https://x.com/miilesus/status/1921944436684038496"
+      },
+      "images": [
+        "images/274.png"
+      ],
+      "prompts": [
+        "create comic style illustration:\n{\n\"style\": \"comic book illustration\",\n\"line_art\": {\n\"type\": \"bold black outlines\",\n\"thickness\": \"medium\",\n\"detail\": \"emphasized contours and shading lines\"\n},\n\"coloring\": {\n\"palette\": \"vibrant and saturated colors\",\n\"shading\": \"halftone dots and cel shading\",\n\"highlighting\": \"strong contrast with pop art effects\"\n},\n\"texture\": {\n\"surface\": \"flat with visible ink strokes\",\n\"effect\": \"printed comic paper texture\"\n},\n\"composition\": {\n\"layout\": \"centered subject\",\n\"background\": \"simple with radial burst or comic-style lines\",\n\"framing\": \"comic panel border\"\n},\n\"lighting\": {\n\"type\": \"dramatic\",\n\"angle\": \"top-left with bold highlights and shadows\"\n},\n\"post_processing\": {\n\"effect\": [\"halftone dots\", \"ink outline\", \"grain\"],\n\"saturation\": \"high\",\n\"contrast\": \"high\"\n},\n\"mood\": \"dynamic and action-oriented\",\n\"format\": \"vertical or square depending on original image\"\n}",
+        "创作漫画风格插画：\n{\n\"风格\": \"漫画书插画\",\n\"线稿\": {\n\"类型\": \"粗黑轮廓线\",\n\"粗细\": \"中等\",\n\"细节\": \"突出的轮廓和阴影线条\"\n},\n\"上色\": {\n\"调色板\": \"鲜艳饱和的色彩\",\n\"阴影\": \"半色调网点和赛璐珞 shading\",\n\"高光\": \"强烈对比，带有波普艺术效果\"\n},\n\"质感\": {\n\"表面\": \"平坦，带有可见的笔触\",\n\"效果\": \"印刷漫画纸质感\"\n},\n\"构图\": {\n\"布局\": \"主体居中\",\n\"背景\": \"简洁，带有放射状爆发图案或漫画风格线条\",\n\"边框\": \"漫画分镜边框\"\n},\n\"光线\": {\n\"类型\": \"戏剧性\",\n\"角度\": \"左上角，带有强烈的高光和阴影\"\n},\n\"后期处理\": {\n\"效果\": [\"半色调网点\", \"墨水轮廓\", \"颗粒感\"],\n\"饱和度\": \"高\",\n\"对比度\": \"高\"\n},\n\"氛围\": \"充满动感和动作感\",\n\"格式\": \"根据原图，为竖版或正方形\"\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "paper-craft"
+      ],
+      "coverImage": "images/274.png"
+    },
+    {
+      "id": 273,
+      "slug": "prompt-273",
+      "title": "超现实主义极简概念广告",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1927459345790288258"
+      },
+      "images": [
+        "images/273.jpeg"
+      ],
+      "prompts": [
+        "“{BRAND or PRODUCT NAME}” — surreal minimal conceptual advertisement\nCreate a 1:1 high-resolution poster that reimagines the brand/product as a surreal object of desire using minimal elements and symbolic storytelling.\n\n• Visual Style: ultra-clean background (light or muted tone), soft lighting, strong negative space\n• Scene Concept: transform the essence of the product into a metaphorical or dreamlike scene\n• Add a short, punchy slogan (2–3 words) that emotionally resonates with the concept\n• Include the brand’s logo in a clean, modern style (integrated naturally into the layout)\n• Composition: centered or rule-of-thirds alignment, use shadows and depth tastefully\n• Mood: artistic, elegant, and thought-provoking — like a museum installation\n• No clutter, no realism overload — just conceptual clarity",
+        "“{品牌或产品名称}”——超现实主义极简概念广告\n创建 1：1 高分辨率海报，使用最少的元素和象征性的故事讲述将品牌/产品重新想象为超现实的欲望对象。\n\n• 视觉风格：超干净的背景（浅色或柔和的色调）、柔和的灯光、强烈的负空间\n• 场景概念：将产品本质转化为隐喻或梦幻般的场景\n• 添加一个简短、有力的口号（2-3 个词），在情感上与概念产生共鸣\n• 以简洁、现代的风格包含品牌标识（自然融入布局）\n• 构图：居中或三分法对齐，巧妙运用阴影和深度\n• 氛围：艺术、优雅、发人深省——就像博物馆装置\n• 没有混乱，没有现实主义超载——只有概念清晰"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "minimalist",
+        "nature",
+        "poster",
+        "product"
+      ],
+      "coverImage": "images/273.jpeg"
+    },
+    {
+      "id": 272,
+      "slug": "prompt-272",
+      "title": "铅笔素描画",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1895481600592269400"
+      },
+      "images": [
+        "images/272.png",
+        "images/272-2.jpeg"
+      ],
+      "prompts": [
+        "A pencil drawing of [Your character], with detailed lines and shading on white paper, capturing the energy and strength in his muscular body [with element effects] around  the character, in a dynamic pose,   tattoo design on paper, manga art style, dark background, high contrast, strong shadows, light and shadow effects, black ink drawing,  dynamic pose",
+        "一幅[你的角色]的铅笔素描画，在白纸上用细致的线条和阴影描绘，捕捉其肌肉发达的身体中蕴含的活力与力量，角色周围带有[元素效果]，呈现出充满动感的姿势，纸上有纹身图案，采用漫画艺术风格，背景偏暗，对比度高，阴影强烈，有光影效果，为黑色墨水画，姿势富有动感。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "paper-craft"
+      ],
+      "coverImage": "images/272.png"
+    },
+    {
+      "id": 271,
+      "slug": "prompt-271",
+      "title": "超现实几何艺术风格的数字插画",
+      "source": {
+        "name": "@fy360593",
+        "url": "https://x.com/fy360593/status/1945042543609008235"
+      },
+      "images": [
+        "images/271.png",
+        "images/271-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a digital illustration with a surreal, geometric art style. Apply glitch textures, abstract shapes, and cinematic composition. Use the original photo’s lighting and color palette to guide the atmosphere, while reimagining the scene in a stylized, dreamy, retro-futuristic way.",
+        "将这张图片转换为具有超现实几何艺术风格的数字插画。应用故障纹理、抽象形状和电影化构图。以原始照片的光线和色彩为基调来营造氛围，同时以一种风格化、梦幻且复古未来主义的方式重新构想这个场景。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "illustration",
+        "landscape",
+        "photography",
+        "retro"
+      ],
+      "coverImage": "images/271.png"
+    },
+    {
+      "id": 270,
+      "slug": "prompt-270",
+      "title": "乐高超级英雄摆出充满动感的动作姿势",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1953186625871331674"
+      },
+      "images": [
+        "images/270.jpeg"
+      ],
+      "prompts": [
+        "Epic LEGO [SUPERHERO] in dynamic action pose showcasing their signature powers, wearing their iconic costume with authentic colors and details, dramatic stormy sky with brilliant lightning bolts illuminating the scene, heroic stance amid swirling LEGO debris and flying bricks, small LEGO minifigures scattered throughout the scene watching in awe, cinematic movie poster composition with photorealistic rendering, epic superhero atmosphere with rich saturated colors, professional depth of field and dramatic lighting effects, 1080x1080 square format",
+        "史诗级乐高【超级英雄】摆出充满动感的动作姿势，展现其标志性超能力，身着标志性服装，色彩和细节真实还原。戏剧性的暴风雨天空中，耀眼的闪电照亮整个场景。超级英雄摆出英勇姿态，周围是旋转的乐高碎片和飞舞的积木块，场景中散落着小型乐高小人仔，它们正惊叹地注视着这一切。整体采用电影海报式构图，配以逼真渲染效果，营造出史诗般的超级英雄氛围，色彩浓郁饱和，运用专业的景深和富有戏剧性的光影效果，尺寸为1080x1080的正方形格式。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "fashion",
+        "landscape",
+        "logo",
+        "nature",
+        "photography",
+        "poster"
+      ],
+      "coverImage": "images/270.jpeg"
+    },
+    {
+      "id": 269,
+      "slug": "prompt-269",
+      "title": "透明X光扫描面板后面",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1953431382836859074"
+      },
+      "images": [
+        "images/269.png",
+        "images/269-2.jpeg"
+      ],
+      "prompts": [
+        "Two anime-style characters standing behind a futuristic transparent X-ray scanning panel, each leaning on it casually. Their full bodies are visible through the glowing glass as stylized, semi-transparent X-ray scans. [INSERT SCAN DETAILS HERE — e.g. hybrid anatomy, supernatural markings, implants, etc.]. Futuristic sci-fi interface overlays on the glass, with holographic HUD elements and glowing digital text. The background is minimal and sterile, resembling a high-tech medical chamber. The characters are [INSERT CHARACTER NAMES & DESCRIPTION HERE — appearance, expression, outfit], drawn in modern high-quality anime style. The scene uses soft colored lighting (e.g. cyan, pink, red depending on the pair), expressive animation, and cinematic composition.",
+        "两个动漫风格的角色站在一个未来感的透明X光扫描面板后面，各自随意地靠在面板上。透过发光的玻璃，可以看到他们的全身呈现出风格化的半透明X光扫描效果。【在此插入扫描细节——例如混合解剖结构、超自然标记、植入物等】。玻璃上叠加着未来科幻界面，还有全息平视显示元素和发光的数字文本。背景简洁而无菌，类似一个高科技医疗舱。角色是【在此插入角色姓名和描述——外貌、表情、服装】，采用现代高品质动漫风格绘制。场景使用柔和的彩色灯光（例如根据角色组合使用青色、粉色、红色等），富有表现力的动态效果和电影化的构图。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fashion",
+        "futuristic",
+        "landscape",
+        "minimalist",
+        "nature",
+        "sci-fi",
+        "ui"
+      ],
+      "coverImage": "images/269.png"
+    },
+    {
+      "id": 268,
+      "slug": "prompt-268",
+      "title": "童趣插画",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1953477354161848322"
+      },
+      "images": [
+        "images/268.jpeg",
+        "images/268-2.jpeg"
+      ],
+      "prompts": [
+        "Create a full body, flat vector illustration of [CHARACTER] in a whimsical, wavy cartoon style. Use thin black outlines and smooth, rounded shapes. The character should have a tiny white-colored head with tiny dot eyes and a simple nose and mouth. The body should have exaggerated, playful proportions. Use bold, flat colors for the clothing. No gradients. No shading. No smudging. Place the character on a solid blue background. Vector friendly. Square aspect ratio.",
+        "创作一幅[角色]的全身扁平矢量插画，采用异想天开的波浪卡通风格。使用纤细的黑色轮廓和流畅的圆形造型。角色应有一个小小的白色头部，上面有极小的圆点眼睛以及简单的鼻子和嘴巴。身体比例要夸张且富有童趣。服装采用鲜明的扁平色彩。不使用渐变、阴影和晕染效果。将角色置于纯蓝色背景上。适合矢量格式。采用正方形比例。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "fashion",
+        "illustration",
+        "vehicle"
+      ],
+      "coverImage": "images/268.jpeg"
+    },
+    {
+      "id": 267,
+      "slug": "prompt-267",
+      "title": "一个复古茶包",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1955240654440894730"
+      },
+      "images": [
+        "images/267.png",
+        "images/267-2.jpeg"
+      ],
+      "prompts": [
+        "A single vintage tea bag lying on a clean white background, hand-painted with an intricate illustration resembling a book cover. The tea bag has delicate aged paper texture, soft warm lighting, and realistic details. On the painted design, leave a clear blank space labeled [BOOK] for the book title. Cinematic, high-resolution, vertical format 9:16.",
+        "一个复古茶包孤零零地放在干净的白色背景上，上面手绘着类似书籍封面的复杂图案。这个茶包有着细腻的陈旧纸张质感，搭配柔和温暖的光线，细节逼真。在手绘图案上，留出一块清晰的空白区域，并标注为【BOOK】，用于填写书名。整体呈现电影般的质感，高分辨率，采用9:16的竖版格式。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "paper-craft",
+        "retro"
+      ],
+      "coverImage": "images/267.png"
+    },
+    {
+      "id": 266,
+      "slug": "prompt-266",
+      "title": "树上挂着产品",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1956047431117770925"
+      },
+      "images": [
+        "images/266.png",
+        "images/266-2.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic photograph of a tree in a scenic meadow, with a sturdy, detailed bark trunk and lush green leaves, where instead of fruits, the branches naturally bear [PRODUCT], seamlessly integrated into the foliage, with realistic textures, natural lighting, soft shadows, subtle imperfections, shot at eye level with a shallow depth of field, ultra-detailed, 8k",
+        "一张超写实的照片，画面中是一片风景优美的草地上的一棵树。树干坚固，树皮纹理清晰，树叶郁郁葱葱、绿意盎然。树枝上长的不是果实，而是自然悬挂着[产品]，它们与树叶无缝融合，纹理逼真。照片采用自然光线，搭配柔和的阴影，带有细微的瑕疵，以平视角度拍摄，景深较浅，细节极致丰富，分辨率为8k。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/266.png"
+    },
+    {
+      "id": 265,
+      "slug": "prompt-265",
+      "title": "品牌杂志",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1957095226813649166"
+      },
+      "images": [
+        "images/265.png",
+        "images/265-2.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic editorial concept for a collaboration between [BRAND] and [MAGAZINE BRAND]. Square 1:1 composition, shot in a sleek Parisian interior with marble floors and tall windows, golden afternoon light illuminating the scene. A single model in a couture gown poses gracefully beside a realistically sized [BRAND] perfume bottle with the [BRAND] logo clearly visible placed on a marble pedestal. Ultra-refined textures, cinematic realism, Vogue-style photography.",
+        "一个超写实的编辑概念，用于[品牌]与[杂志品牌]的合作。1:1的正方形构图，在时尚的巴黎室内拍摄，室内设有大理石地板和高大的窗户，金色的午后阳光照亮整个场景。一位身着高级定制礼服的模特优雅地摆着姿势，身旁是一个尺寸逼真的[品牌]香水瓶，瓶身上清晰可见[品牌]的标志，香水瓶放置在大理石基座上。超精细的纹理，电影般的写实感，《 Vogue》风格的摄影。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "interior",
+        "landscape",
+        "logo",
+        "photography"
+      ],
+      "coverImage": "images/265.png"
+    },
+    {
+      "id": 264,
+      "slug": "prompt-264",
+      "title": "纸制玩具版本",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1961411111879594453"
+      },
+      "images": [
+        "images/264.png"
+      ],
+      "prompts": [
+        "Ultra-detailed render of a [CHARACTER NAME] paper toy version in box form (papertoy) made from matte folded cardboard and cut with visible paper texture, clean edges and neat folds. Cubic head and body, square extremities, simplified facial features, flat printed colors and subtle shading for greater depth. The clothing and accessories faithfully imitate the appearance of the reference image in a minimalist geometric papercraft style, maintaining compact proportions and chibi style. Neutral studio lighting, soft shadows, smooth background, photorealistic product photography, 4K, no text or logos. 1080x1080 dimension.",
+        "超细节渲染的[角色名称]纸制玩具版本，呈盒子形状（纸制玩具），由哑光折叠纸板制成，带有可见的纸张纹理，边缘干净，折叠整齐。头部和身体为立方体，四肢为方形，面部特征简化，采用平面印刷色彩和微妙阴影以增强深度。服装和配饰以极简几何纸艺风格忠实地模仿参考图的外观，保持紧凑比例和Q版风格。中性工作室灯光，柔和阴影，平滑背景，逼真的产品摄影效果，4K分辨率，无文字或标志。尺寸为1080x1080。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fashion",
+        "logo",
+        "minimalist",
+        "paper-craft",
+        "photography",
+        "product",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/264.png"
+    },
+    {
+      "id": 263,
+      "slug": "prompt-263",
+      "title": "低多边形马赛克风格",
+      "source": {
+        "name": "@fy360593",
+        "url": "https://x.com/fy360593/status/1945118291703284152"
+      },
+      "images": [
+        "images/263.jpeg",
+        "images/263-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a refined low-poly mosaic style. Preserve the original structure and recognizable details, especially facial features and contours. Use small, high-density polygons to maintain clarity and identity while creating a crystalline, faceted look. Keep the original color palette for a harmonious and natural aesthetic. Avoid altering or adding new elements.",
+        "将这张图片转换为精致的低多边形马赛克风格。保留原始结构和可识别的细节，尤其是面部特征和轮廓。使用小而密集的多边形，在保持清晰度和辨识度的同时，营造出水晶般的多面效果。保留原始色调，以获得和谐自然的美感。避免修改或添加新元素。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature"
+      ],
+      "coverImage": "images/263.jpeg"
+    },
+    {
+      "id": 262,
+      "slug": "prompt-262",
+      "title": "街头顽童（Gorillaz）风格插画",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1942586412920103180"
+      },
+      "images": [
+        "images/262.png",
+        "images/262-2.jpeg"
+      ],
+      "prompts": [
+        "Restyle this image into a gritty Gorillaz-style illustration, bold thick black outlines, sharp angular edges, flat expressive lighting, stylized high-contrast shadows, dirty distressed surface textures, muted color palette: washed-out teals, olive greens, rusty reds, mustard yellows, dusty browns, raw grungy urban atmosphere, comic book flatness mixed with painterly grit, hand-drawn finish with faded gradients, graphic novel aesthetic\nwith a rebellious, animated tone, dark stylish tone, full of attitude.",
+        "将这张图片重新设计成粗粝的街头顽童（Gorillaz）风格插画，采用粗重的黑色轮廓线、锐利的棱角、扁平化的富有表现力的光线、风格化的高对比度阴影、粗糙破旧的表面纹理；色彩搭配柔和暗淡：褪色的蓝绿色、橄榄绿、锈红色、芥末黄、土褐色；营造出原始粗粝的都市氛围，融合漫画的扁平化与绘画的颗粒感，带有褪色渐变效果的手绘质感，呈现出漫画小说的美学风格，整体基调叛逆、生动且时尚暗黑，充满个性。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "illustration"
+      ],
+      "coverImage": "images/262.png"
+    },
+    {
+      "id": 261,
+      "slug": "prompt-261",
+      "title": "城市糖果传奇的风格",
+      "source": {
+        "name": "@miilesus",
+        "url": "https://x.com/miilesus/status/1939690110418833592"
+      },
+      "images": [
+        "images/261.jpeg",
+        "images/261-2.jpeg"
+      ],
+      "prompts": [
+        "A colorful, playful 2D map of [city name], in the style of Candy Crush Saga, featuring the city’s iconic landmarks as candy-inspired buildings, cute gumdrop trees, licorice bridges, pastel roads, and glossy water elements, floating clouds, vibrant cartoon style, top-down view, kid-friendly game aesthetics, horizontal layout",
+        "一幅色彩丰富、充满童趣的[城市名称]2D地图，采用《糖果传奇》的风格，将城市的标志性地标设计成糖果风格的建筑，还有可爱的软糖树、甘草桥、柔和色调的道路、富有光泽的水域元素、漂浮的云朵，整体为鲜艳的卡通风格，采用俯视视角，具有适合儿童的游戏美学，为横向布局。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "cartoon",
+        "gaming",
+        "logo",
+        "vehicle"
+      ],
+      "coverImage": "images/261.jpeg"
+    },
+    {
+      "id": 260,
+      "slug": "prompt-260",
+      "title": "20世纪20年代亚瑟·拉克姆风格的童话插画",
+      "source": {
+        "name": "@vkuoo",
+        "url": "https://x.com/vkuoo/status/1929708611208728874"
+      },
+      "images": [
+        "images/260.png",
+        "images/260-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a 1920s fairy tale illustration in the style of Arthur Rackham. Use muted watercolor tones and intricate ink linework. Fill the scene with whimsical forest creatures, twisted tree branches, and hidden magical objects. The overall tone should be mysterious, enchanting, and slightly eerie. Add handwritten calligraphy-style captions and riddles.",
+        "将这张图片转换成20世纪20年代亚瑟·拉克姆风格的童话插画。采用柔和的水彩色调和精致的墨水线条。场景中要充满奇幻的森林生物、扭曲的树枝和隐藏的魔法物品。整体基调应神秘、迷人且略带诡异。添加手写书法风格的说明文字和谜语。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "fantasy",
+        "illustration",
+        "landscape"
+      ],
+      "coverImage": "images/260.png"
+    },
+    {
+      "id": 259,
+      "slug": "prompt-259",
+      "title": "20世纪30年代弗莱舍工作室风格的动画",
+      "source": {
+        "name": "@vkuoo",
+        "url": "https://x.com/vkuoo/status/1930065671083438244"
+      },
+      "images": [
+        "images/259.png",
+        "images/259-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a 1930s animation storyboard in the style of Fleischer Studios. Use greyscale with expressive inky shading and rubber-hose limbs. Surround the scene with anthropomorphic objects, bouncy motion lines, and slapstick action. The overall tone should be jazzy, lively, and playful. Add hand-lettered sound effects and quirky dialogue signs.",
+        "将这张图片转换成20世纪30年代弗莱舍工作室风格的动画分镜。采用灰度色调，搭配富有表现力的墨色阴影和“橡胶管”式肢体线条。场景中要加入拟人化的物体、富有弹性的运动线和闹剧式的动作。整体基调应充满爵士感、活力与趣味。添加手写风格的音效文字和古怪的对话标牌。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "landscape"
+      ],
+      "coverImage": "images/259.png"
+    },
+    {
+      "id": 258,
+      "slug": "prompt-258",
+      "title": "20世纪50年代的海报",
+      "source": {
+        "name": "@vkuoo",
+        "url": "https://x.com/vkuoo/status/1930564137526137166"
+      },
+      "images": [
+        "images/258.png",
+        "images/258-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a 1950s poster in the style of mid-century modern graphic designers. Use flat, geometric color blocks with strong typographic elements.  The overall tone should be optimistic, nostalgic, and promotional. Add bold location labels and promotional slogans.",
+        "将这张图片转换成20世纪50年代的海报，风格参考中世纪现代平面设计师的作品。采用扁平的几何色块，搭配醒目的排版元素。整体基调应乐观、怀旧且具有宣传性。添加醒目的地点标签和宣传标语。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "poster",
+        "typography"
+      ],
+      "coverImage": "images/258.png"
+    },
+    {
+      "id": 257,
+      "slug": "prompt-257",
+      "title": "透明蜂窝状变形",
+      "source": {
+        "name": "@miilesus",
+        "url": "https://x.com/miilesus/status/1930266127961059739"
+      },
+      "images": [
+        "images/257.png",
+        "images/257-2.jpeg"
+      ],
+      "prompts": [
+        "{\n  \"object\": \"OBJECT_NAME\",\n  \"style\": \"Transparent Honeycomb Transformation\",\n  \"description\": \"Transform the object into a structure made entirely of crystallized golden honey with high transparency. The surface should be ultra-glossy, semi-liquid, and light-reflective, with defined yet see-through hexagonal honeycomb patterns. Parts of the object should allow light to pass through, revealing inner layers and structure. Include gentle honey drips for realism.\",\n  \"material\": {\n    \"primary\": \"Crystal-clear amber honey\",\n    \"secondary\": \"Translucent honeycomb cells\"\n  },\n  \"texture\": {\n    \"surface\": \"Ultra glossy and semi-liquid\",\n    \"pattern\": \"See-through hexagonal honeycomb\",\n    \"drips\": true\n  },\n  \"effects\": {\n    \"translucency\": \"highly translucent\",\n    \"internal_glow\": \"Soft warm light from within\",\n    \"emblem\": \"Delicate bee icon subtly embedded in the structure\"\n  },\n  \"presentation\": {\n    \"background\": \"Clean white or soft gradient\",\n    \"lighting\": \"Backlit with soft diffusion to enhance translucency\",\n    \"floating\": true,\n    \"format\": \"Square\"\n  }\n}",
+        "{\n  \"物体\": \"OBJECT_NAME\",\n  \"风格\": \"透明蜂窝状变形\",\n  \"描述\": \"将该物体转变为由完全结晶的金色蜂蜜制成的结构，具有高度透明度。表面应呈现超 glossy 质感、半液态状态和反光效果，带有清晰可辨且透明的六边形蜂窝图案。物体的部分区域应允许光线穿透，以展现内部层次和结构。为增强真实感，需加入自然垂落的蜂蜜滴。\",\n  \"材质\": {\n    \"主要材质\": \"清澈透明的琥珀色蜂蜜\",\n    \"次要材质\": \"半透明的蜂窝单元\"\n  },\n  \"纹理\": {\n    \"表面\": \"超 glossy 且呈半液态\",\n    \"图案\": \"透明的六边形蜂窝\",\n    \"滴落效果\": true\n  },\n  \"特效\": {\n    \"半透明性\": \"高度半透明\",\n    \"内部光晕\": \"源自内部的柔和暖光\",\n    \"标志\": \"精致的蜜蜂图标巧妙嵌入结构中\"\n  },\n  \"呈现方式\": {\n    \"背景\": \"纯净白色或柔和渐变\",\n    \"光线\": \"背光搭配柔和漫射效果，以增强半透明感\",\n    \"悬浮效果\": true,\n    \"格式\": \"正方形\"\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "logo",
+        "nature"
+      ],
+      "coverImage": "images/257.png"
+    },
+    {
+      "id": 256,
+      "slug": "prompt-256",
+      "title": "漂浮玻璃霓虹3D",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1940054985418375269"
+      },
+      "images": [
+        "images/256.jpeg"
+      ],
+      "prompts": [
+        "retexture the image attached based on the JSON below:\n\n{\n  \"style_name\": \"Floating Glassy Neon 3D\",\n  \"retexture_mode\": \"shape_lock\",\n  \"object_analysis\": {\n    \"preserve_silhouette\": true,\n    \"geometry_sensitive_mapping\": true,\n    \"detail_retention\": \"maintain contours, volumes, and layering\"\n  },\n  \"material_properties\": {\n    \"base_material\": \"translucent neon glass-gel\",\n    \"surface_finish\": \"semi-gloss with soft glow edges\",\n    \"transparency\": \"high, with soft light refraction\",\n    \"refraction\": \"gentle bend with subtle halo on curves\",\n    \"embedded_effects\": \"internal light scatter and edge neon glow\",\n    \"color_blend\": {\n      \"primary\": [\"aqua\", \"electric blue\", \"neon violet\"],\n      \"gradient_direction\": \"top-left to bottom-right\",\n      \"transition_smoothness\": \"very smooth\"\n    }\n  },\n  \"lighting\": {\n    \"type\": \"softbox HDRI\",\n    \"intensity\": \"soft and bright\",\n    \"source_direction\": \"overhead and slightly front\",\n    \"highlight_behavior\": \"gentle bloom with glass sparkle\"\n  },\n  \"shadow_behavior\": {\n    \"type\": \"floating contact shadow\",\n    \"appearance\": \"extremely soft, blurred ellipse\",\n    \"opacity\": 0.07,\n    \"distance_below_object\": \"moderate\",\n    \"color\": \"neutral gray\"\n  },\n  \"background\": {\n    \"type\": \"solid color\",\n    \"color\": \"#ffffff\",\n    \"glow_effect\": \"none\",\n    \"gradient\": \"none\"\n  },\n  \"rendering\": {\n    \"depth_of_field\": \"subtle with slight vignette\",\n    \"focus_point\": \"center of floating object\",\n    \"ambient_occlusion\": \"minimal to preserve light feel\",\n    \"render_engine\": \"3D stylized with light diffusion and high specular detail\",\n    \"camera_angle\": \"slightly above object, frontal\",\n    \"resolution\": \"very high for product branding\"\n  },\n  \"special_effects\": {\n    \"floating_behavior\": true,\n    \"visual_weightlessness\": true,\n    \"shadow_softness\": \"maximum\"\n  }\n}",
+        "根据以下JSON对附加图片进行重新纹理处理：\n\n{\n  \"风格名称\": \"漂浮玻璃霓虹3D\",\n  \"重纹理模式\": \"形状锁定\",\n  \"对象分析\": {\n    \"保留轮廓\": true,\n    \"几何敏感映射\": true,\n    \"细节保留\": \"维持轮廓、体积和层次感\"\n  },\n  \"材质属性\": {\n    \"基础材质\": \"半透明霓虹玻璃胶\",\n    \"表面处理\": \"半光泽，边缘带有柔和光晕\",\n    \"透明度\": \"高，带有柔和的光折射\",\n    \"折射效果\": \"轻微弯曲，曲线处有微妙光晕\",\n    \"内置效果\": \"内部光散射和边缘霓虹发光\",\n    \"色彩混合\": {\n      \"主色\": [\"水绿色\", \"电蓝色\", \"霓虹紫\"],\n      \"渐变方向\": \"左上角至右下角\",\n      \"过渡平滑度\": \"非常平滑\"\n    }\n  },\n  \"光照\": {\n    \"类型\": \"柔光箱HDRI\",\n    \"强度\": \"柔和明亮\",\n    \"光源方向\": \" overhead 且略微偏前\",\n    \"高光表现\": \"柔和光晕，带有玻璃闪光\"\n  },\n  \"阴影表现\": {\n    \"类型\": \"漂浮接触阴影\",\n    \"外观\": \"极其柔和、模糊的椭圆形\",\n    \"不透明度\": 0.07,\n    \"物体下方距离\": \"适中\",\n    \"颜色\": \"中性灰\"\n  },\n  \"背景\": {\n    \"类型\": \"纯色\",\n    \"颜色\": \"#ffffff\",\n    \"发光效果\": \"无\",\n    \"渐变\": \"无\"\n  },\n  \"渲染\": {\n    \"景深\": \"轻微，带有轻微渐晕\",\n    \"焦点\": \"漂浮物体的中心\",\n    \"环境光遮蔽\": \"最小化以保持明亮感\",\n    \"渲染引擎\": \"3D风格化，带有光扩散和高镜面细节\",\n    \"相机角度\": \"略高于物体，正面视角\",\n    \"分辨率\": \"极高，适用于产品品牌推广\"\n  },\n  \"特殊效果\": {\n    \"漂浮效果\": true,\n    \"视觉失重感\": true,\n    \"阴影柔和度\": \"最大\"\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "neon",
+        "product"
+      ],
+      "coverImage": "images/256.jpeg"
+    },
+    {
+      "id": 255,
+      "slug": "prompt-255",
+      "title": "头部的几何肖像",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1954831239996694902"
+      },
+      "images": [
+        "images/255.jpeg",
+        "images/255-2.jpeg"
+      ],
+      "prompts": [
+        "Design a geometric portrait of a [ANIMAL] head in the style of contemporary paper craft collage. Use multiple overlapping paper textures and shadow effects to build dimensional depth. Focus on botanical-inspired color palettes with matte finish aesthetics. The composition should feature bold, angular cuts that form the animal’s distinctive characteristics while maintaining facial symmetry. Set against a minimalist backdrop with subtle gradient. The final piece should evoke the craftsmanship of museum-quality paper installations. Square format, 1080x1080 pixels.",
+        "设计一幅[动物]头部的几何肖像，采用当代纸艺拼贴风格。运用多种重叠的纸张纹理和阴影效果来构建立体深度。聚焦于植物灵感的色彩搭配，呈现哑光质感美学。构图应采用大胆的棱角切割，既塑造出该动物的独特特征，又保持面部对称性。背景为简约风格，带有微妙的渐变效果。最终作品需展现出博物馆级纸艺装置的精湛工艺。尺寸为正方形，1080x1080像素。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "animal",
+        "character",
+        "minimalist",
+        "paper-craft",
+        "pixel",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/255.jpeg"
+    },
+    {
+      "id": 254,
+      "slug": "prompt-254",
+      "title": "磨砂泡泡 3D 图标",
+      "source": {
+        "name": "@Anima_Labs",
+        "url": "https://x.com/Anima_Labs/status/1953762725965799627"
+      },
+      "images": [
+        "images/254.png",
+        "images/254-2.jpeg"
+      ],
+      "prompts": [
+        "{\n\"style_name\": \"Frosted Bubble 3D Icons\",\n\"render_mode\": \"3d_semi_transparent_detailed\",\n\"icon_subject\": \"{{icon_ PlayStation controller}}\",\n\"object_analysis\": {\n\"preserve_silhouette\": true,\n\"geometry_sensitive_mapping\": true,\n\"detail_retention\": \"smooth rounded edges, subtle internal reflections\"\n},\n\"material_properties\": {\n\"base_material\": [\n\"frosted translucent plastic\",\n\"semi-transparent matte acrylic\"\n],\n\"internal_elements\": \"floating colorful spheres, visible through the outer shell\",\n\"surface_finish\": \"frosted, diffused matte texture with light translucency\",\n\"texture_behavior\": \"no external color tint, transparency reveals inner objects\",\n\"branding_elements\": \"none\"\n},\n\"color_palette\": {\n\"primary\": [\"#FFFFFF\", \"#F5F5F5\"],\n\"accents\": [\"#FF69B4\", \"#FFA500\", \"#6A5ACD\", \"#00CED1\", \"#FFD700\"],\n\"contrast\": \"very high\"\n},\n\"lighting\": {\n\"type\": \"soft ambient + rim lighting\",\n\"intensity\": \"high\",\n\"shadows\": \"soft glow under the object\",\n\"highlights\": \"faint edge glow and top soft reflection\"\n},\n\"rendering\": {\n\"style\": \"modern 3D icon with internal color elements\",\n\"background\": \"pure black\",\n\"camera_angle\": \"isometric 3/4 view\",\n\"depth_of_field\": \"none, all details in focus\"\n},\n\"style_notes\": [\n\"black background increases bubble color visibility\",\n\"frosted transparency should glow subtly against black\",\n\"perfect for high-contrast, collectible-style icons\"\n]\n}",
+        "{\n\"风格名称\": \"磨砂泡泡3D图标\",\n\"渲染模式\": \"3d_semi_transparent_detailed（3D半透明精细）\",\n\"图标主题\": \"{{图标_PlayStation手柄}}\",\n\"对象分析\": {\n\"保留轮廓\": true,\n\"几何敏感映射\": true,\n\"细节保留\": \"平滑的圆角边缘，细微的内部反射\"\n},\n\"材质属性\": {\n\"基础材质\": [\n\"磨砂半透明塑料\",\n\"半透明哑光亚克力\"\n],\n\"内部元素\": \"漂浮的彩色球体，可透过外壳看到\",\n\"表面处理\": \"磨砂、漫射哑光质感，带有轻微透光性\",\n\"纹理表现\": \"无外部色彩 tint，透明度可展现内部物体\",\n\"品牌元素\": \"无\"\n},\n\"色彩搭配\": {\n\"主色\": [\"#FFFFFF\", \"#F5F5F5\"],\n\"强调色\": [\"#FF69B4\", \"#FFA500\", \"#6A5ACD\", \"#00CED1\", \"#FFD700\"],\n\"对比度\": \"极高\"\n},\n\"光照\": {\n\"类型\": \"柔和环境光+轮廓光\",\n\"强度\": \"高\",\n\"阴影\": \"物体下方柔和光晕\",\n\"高光\": \"微弱的边缘发光和顶部柔和反射\"\n},\n\"渲染\": {\n\"风格\": \"带有内部彩色元素的现代3D图标\",\n\"背景\": \"纯黑色\",\n\"相机角度\": \"等距3/4视图\",\n\"景深\": \"无，所有细节均清晰对焦\"\n},\n\"风格说明\": [\n\"黑色背景提升泡泡色彩的可见度\",\n\"磨砂透明度在黑色背景下应呈现微妙的发光效果\",\n\"非常适合高对比度、收藏品风格的图标\"\n]\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "branding"
+      ],
+      "coverImage": "images/254.png"
+    },
+    {
+      "id": 253,
+      "slug": "prompt-253",
+      "title": "亚克力钥匙扣",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1954931461309546821"
+      },
+      "images": [
+        "images/253.jpeg",
+        "images/253-2.jpeg"
+      ],
+      "prompts": [
+        "Create a photorealistic square image (1080x1080) showing a custom acrylic keychain version of the [LOGO] logo hanging from the zipper of a dark-colored backpack (e.g. black or grey). The logo must retain its original shape, color, and proportions without any alteration. The keychain should have a clear glossy acrylic layer, clipped with a silver metal ring and clasp. Use soft daylight or diffused lighting to avoid yellow tones. Set the background in a modern outdoor setting, but keep it blurred to maintain focus on the logo keychain.",
+        "创建一张逼真的方形图片（1080x1080 像素），展示一个定制的 [LOGO] 标志亚克力钥匙扣，它挂在一个深色背包（如黑色或灰色）的拉链上。该标志必须保持其原始形状、颜色和比例，不得有任何改动。钥匙扣应有一层透明的光泽亚克力，配有银色金属环和扣具。使用柔和的日光或漫射光，避免黄色调。背景设置为现代户外环境，但需模糊处理，以将焦点保持在标志钥匙扣上。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "logo",
+        "photography",
+        "pixel"
+      ],
+      "coverImage": "images/253.jpeg"
+    },
+    {
+      "id": 252,
+      "slug": "prompt-252",
+      "title": "怪诞又梦幻的超现实插画",
+      "source": {
+        "name": "@fy360593",
+        "url": "https://x.com/fy360593/status/1955265393188286632"
+      },
+      "images": [
+        "images/252.png",
+        "images/252-2.jpeg"
+      ],
+      "prompts": [
+        "Transform the uploaded image into a surreal illustration with a whimsical, dream‑like vibe.\n• Color palette: muted tones (soft greens, browns, greys) with occasional gentle pops of green.\n• Lighting: soft, diffused, almost ethereal light that blends gradients and subtle highlights.\n• Texture & medium feel: oil‑painting‑like brushstrokes, faint watercolor washes, or loose hand‑drawn linework, with a slight grainy texture.\n• Mood & composition: exaggerated, expressive features (e.g., elongated faces or emotive eyes) characteristic of cartoonish or Muppet‑style illustrations, but applied in a surreal, slightly fantastical context.\n• Overall aesthetic: blend realistic attention to detail with a touch of surreal whimsy—think serene, slightly uncanny atmosphere.",
+        "将上传的图片转换为一幅超现实插画，营造出怪诞又梦幻的氛围。\n色彩搭配：采用柔和色调（浅绿、棕色、灰色），偶尔点缀一抹淡雅的绿色。\n光线效果：柔和、弥漫的近乎空灵的光线，融合渐变色与细微的高光。\n质感与媒介感：类似油画的笔触、淡淡的水彩晕染或松散的手绘线条，带有轻微的颗粒质感。\n氛围与构图：具有夸张、富有表现力的特征（如拉长的脸型或饱含情感的眼睛），这是卡通或提线木偶风格插画的典型特点，但要将其应用于超现实、略带奇幻色彩的场景中。\n整体美学：将对细节的真实刻画与一丝超现实的怪诞感相融合 —— 营造出一种宁静又略带诡异的氛围。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "fantasy",
+        "illustration",
+        "landscape",
+        "vehicle"
+      ],
+      "coverImage": "images/252.png"
+    },
+    {
+      "id": 251,
+      "slug": "prompt-251",
+      "title": "超细节盒状纸艺玩具",
+      "source": {
+        "name": "@Arminn_Ai",
+        "url": "https://x.com/Arminn_Ai/status/1954985717609730175"
+      },
+      "images": [
+        "images/251.jpeg",
+        "images/251-2.jpeg"
+      ],
+      "prompts": [
+        "1×1 square, ultra-detailed render of a box-shaped papertoy version of [CHARACTER NAME]. Made from folded and cut matte cardstock with visible paper texture, crisp edges, and clean folds. Cubic head and body, blocky limbs, simplified facial features, flat printed colors, and subtle shading for depth. Clothing and accessories faithfully mimic [CHARACTER NAME]’s iconic look in a minimal geometric papercraft style, keeping proportions compact and chibi-like. Neutral studio lighting, soft shadows, plain background, photorealistic product photography, 4K, no text or logos.",
+        "1×1大小的正方形，超细节渲染的[角色名称]盒状纸艺玩具版本。由折叠和裁剪的哑光卡纸制成，具有可见的纸张纹理、清晰的边缘和整齐的折痕。立方体头部和身体，块状四肢，简化的面部特征，平印色彩，以及用于体现深度的微妙阴影。服装和配饰以简约的几何纸艺风格忠实还原[角色名称]的标志性外观，保持紧凑的比例和Q版风格。中性工作室灯光，柔和阴影，简洁背景，逼真的产品摄影效果，4K分辨率，无文字或标志。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fashion",
+        "logo",
+        "minimalist",
+        "paper-craft",
+        "photography",
+        "product",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/251.jpeg"
+    },
+    {
+      "id": 250,
+      "slug": "prompt-250",
+      "title": "被优雅水漩涡环绕的品牌产品",
+      "source": {
+        "name": "@Morph_VGart",
+        "url": "https://x.com/Morph_VGart/status/1933966476492353807"
+      },
+      "images": [
+        "images/250.png",
+        "images/250-2.jpeg"
+      ],
+      "prompts": [
+        "Create square image of studio-lit product photography of a [Product] suspended in mid-air, lots of thick dynamic water swirls surrounding it in slow-motion arcs, crystal-clear droplets glistening with light refraction, high-gloss finish, minimal backdrop, cinematic lighting with soft shadows and highlights, shot on a pure matching gradient background, ultra-realistic detail, commercial photography style, 85mm lens depth of field.",
+        "创建一个方形图像，是工作室照明的产品摄影，一个[产品]悬浮在空中，周围有许多厚重的动态水漩涡以慢动作弧线环绕，晶莹剔透的液滴折射着光线，高光泽度，简约背景，电影般的照明，柔和的阴影和高光，在纯色匹配渐变背景上拍摄，超逼真的细节，商业摄影风格，85mm 镜头景深。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/250.png"
+    },
+    {
+      "id": 249,
+      "slug": "prompt-249",
+      "title": "路牌图片",
+      "source": {
+        "name": "@diegocabezas01",
+        "url": "https://x.com/diegocabezas01/status/1950693677023535318"
+      },
+      "images": [
+        "images/249.jpeg",
+        "images/249-2.jpeg"
+      ],
+      "prompts": [
+        "Image of a billboard with the text: “Image of a billboard with the text:”",
+        "路牌图片，上面写着：“路牌图片，上面写着：”"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/249.jpeg"
+    },
+    {
+      "id": 248,
+      "slug": "prompt-248",
+      "title": "一张铅笔素描",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1895481600592269400"
+      },
+      "images": [
+        "images/248.png",
+        "images/248-2.jpeg"
+      ],
+      "prompts": [
+        "A pencil drawing of [Your character], with detailed lines and shading on white paper, capturing the energy and strength in his muscular body [with element effects] around  the character, in a dynamic pose,   tattoo design on paper, manga art style, dark background, high contrast, strong shadows, light and shadow effects, black ink drawing,  dynamic pose",
+        "一张铅笔素描，描绘了 [你的角色]，在白纸上用细致的线条和阴影，捕捉了他肌肉身体中的能量和力量 [带有元素效果] 围绕着角色，动态姿势，纸上的纹身设计，漫画艺术风格，深色背景，高对比度，强烈的阴影，光影效果，黑色墨水绘画，动态姿势"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "paper-craft"
+      ],
+      "coverImage": "images/248.png"
+    },
+    {
+      "id": 247,
+      "slug": "prompt-247",
+      "title": "90年代美国卡通片定格动画风格插画",
+      "source": {
+        "name": "@cuchocapilla",
+        "url": "https://x.com/cuchocapilla/status/1934280060292284492"
+      },
+      "images": [
+        "images/247.jpeg",
+        "images/247-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a 90s American cartoon cel-style illustration. Use thick black outlines, flat bold colors, and sharp cel shading with hard shadows. Emphasize exaggerated facial expressions and stylized, geometric character shapes. The background should be flat or minimal to keep the focus on the character. The whole image should feel like a frame from a Saturday morning cartoon.",
+        "将这张图片转化为 90 年代美国卡通片定格动画风格插画。使用粗黑轮廓线、平面化鲜明的颜色，以及锐利的定格动画阴影效果和硬阴影。强调夸张的面部表情和风格化的几何角色形状。背景应为平面或极简，以突出角色。整张图片应感觉像是从周六早间卡通片中截取的一帧。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "illustration",
+        "minimalist",
+        "vehicle"
+      ],
+      "coverImage": "images/247.jpeg"
+    },
+    {
+      "id": 246,
+      "slug": "prompt-246",
+      "title": "色彩缤纷的手工雕塑",
+      "source": {
+        "name": "@Deshraj4x",
+        "url": "https://x.com/Deshraj4x/status/1938670486285885772"
+      },
+      "images": [
+        "images/246.jpeg"
+      ],
+      "prompts": [
+        "A colorful handcrafted sculpture of [insert subject], made from semi-transparent ice blocks in custom shapes. Accents like icing, candy, yarn, or fruit skin enhance facial features, texture, or accessories. Placed on a ceramic plate over a leaf or decorative mat, with a clean, softly lit studio or natural tabletop background. Lighting highlights the glossy ice texture, blending food art, toy design, and photography into a playful, artistic composition.",
+        "一个色彩缤纷的手工雕塑，由[插入主题]制成，使用半透明的冰块，形状定制。装饰如糖霜、糖果、毛线或水果皮增强了面部特征、纹理或配饰。放置在陶瓷盘上，盘上覆盖着叶子或装饰垫，背景是干净、柔和照明的摄影棚或自然桌面。光线突出了冰块的光泽质感，将食品艺术、玩具设计和摄影融合成一种俏皮、艺术性的构图。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "food",
+        "nature",
+        "photography",
+        "sculpture",
+        "toy"
+      ],
+      "coverImage": "images/246.jpeg"
+    },
+    {
+      "id": 245,
+      "slug": "prompt-245",
+      "title": "Kiro卡通幽灵",
+      "source": {
+        "name": "@松果先森",
+        "url": "https://x.com/songguoxiansen/status/1945032571114402108"
+      },
+      "images": [
+        "images/245.jpeg"
+      ],
+      "prompts": [
+        "A cute cartoon ghost is the absolute main subject of the picture. It has a pure white body with a smooth and rounded contour, and two simple black oval eyes, with no extra features. This ghost is floating quietly in the very center of the picture. The background is a pure, bright purple, creating a simple, modern, and friendly atmosphere. The composition is a centered close-up, and the aspect ratio is 1:1 square. There is no text in the entire image. The image style is typical flat design and vector art, minimalist, much like an app icon or a logo, characterized by clean lines and solid color blocks, without any gradients or textural details. The image quality required is high-resolution with clean, sharp edges. The overall feeling it gives is one of a cute, simple, and modern piece of digital art.",
+        "一个可爱的卡通鬼魂是图片的绝对主体。它拥有纯白色的身体，轮廓平滑圆润，两只简单的黑色椭圆形眼睛，没有任何额外特征。这个鬼魂安静地漂浮在图片的正中央。背景是纯亮的紫色，营造出简洁、现代和友好的氛围。构图是居中的特写，宽高比为 1:1 的正方形。整个图像中没有文字。图像风格典型的扁平化设计和矢量艺术，极简主义，类似于应用图标或标志，以干净的线条和实色块为特点，没有任何渐变或纹理细节。要求的图像质量是高分辨率，边缘清晰锐利。它给人的整体感觉是一幅可爱、简洁、现代的数字艺术作品。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "logo",
+        "minimalist",
+        "vehicle"
+      ],
+      "coverImage": "images/245.jpeg"
+    },
+    {
+      "id": 244,
+      "slug": "prompt-244",
+      "title": "转换马赛克风格照片",
+      "source": {
+        "name": "@fy360593",
+        "url": "https://x.com/fy360593/status/1945118291703284152"
+      },
+      "images": [
+        "images/244.png",
+        "images/244-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a refined low-poly mosaic style. Preserve the original structure and recognizable details, especially facial features and contours. Use small, high-density polygons to maintain clarity and identity while creating a crystalline, faceted look. Keep the original color palette for a harmonious and natural aesthetic. Avoid altering or adding new elements.",
+        "将此图像转换为精致的低多边形马赛克风格。保留原始结构和可识别的细节，特别是面部特征和轮廓。使用小而高密度的多边形，以保持清晰度和身份，同时创造水晶般、多面体的外观。保留原始调色板，以实现和谐自然的美学。避免更改或添加新元素。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature"
+      ],
+      "coverImage": "images/244.png"
+    },
+    {
+      "id": 243,
+      "slug": "prompt-243",
+      "title": "卡通照片转换",
+      "source": {
+        "name": "@fy360593",
+        "url": "https://x.com/fy360593/status/1945395833123561930"
+      },
+      "images": [
+        "images/243.png",
+        "images/243-2.jpeg"
+      ],
+      "prompts": [
+        "Transform the character into a digital, half-body cartoon-style portrait. Use a playful, vector-friendly style with clean solid lines, rounded face, oversized googly eyes, and minimal facial details. Show the character from chest up, including shoulders and upper torso. Apply smooth gradient fills to both the character and background for a colorful, soft look. Square format.",
+        "将角色转化为数字化的半身卡通风格肖像。使用适合矢量的俏皮风格，线条干净利落，圆润的脸庞，超大号的玻璃眼球，以及极简的面部细节。展示角色胸部以上的部分，包括肩膀和上半身。对角色和背景都应用平滑的渐变填充，营造色彩丰富、柔和的视觉效果。方形格式。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "minimalist",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/243.png"
+    },
+    {
+      "id": 242,
+      "slug": "prompt-242",
+      "title": "有趣的块状 3D 世界",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1948690449293869081"
+      },
+      "images": [
+        "images/242.png",
+        "images/242-2.jpeg"
+      ],
+      "prompts": [
+        "Retexture the image attached based on the JSON below\n{\n  \"style_name\": \"Playful Chunky 3D Aesthetic\",\n  \"retexture_mode\": \"stylized_3d_overlay\",\n  \"object_analysis\": {\n    \"preserve_silhouette\": true,\n    \"geometry_sensitive_mapping\": true,\n    \"detail_retention\": \"moderate — focus on key forms and proportions\"\n  },\n  \"material_properties\": {\n    \"base_material\": [\"soft matte plastic\", \"rubbery polymer\"],\n    \"surface_details\": [\n      \"rounded edges and inflated volumes\",\n      \"smooth, toy-like finish\",\n      \"minimal seam lines\"\n    ]\n  },\n  \"lighting\": {\n    \"type\": \"studio diffused light\",\n    \"intensity\": \"medium\",\n    \"shadows\": \"soft base shadows\",\n    \"highlight_behavior\": \"gentle gloss on curves and raised surfaces\"\n  },\n  \"color_palette\": {\n    \"dominant_colors\": [\"#f6f6f6\", \"#3a3a3a\", \"#f05423\"],\n    \"accent_colors\": [\"#ff875d\", \"#b0b0b0\", \"#f3f3f3\"]\n  },\n  \"background\": {\n    \"color\": \"#f9f9f9\",\n    \"type\": \"solid\",\n    \"texture\": \"none\"\n  },\n  \"style_tags\": [\n    \"3D cartoon realism\",\n    \"UI icon pack aesthetic\",\n    \"inflated minimalism\",\n    \"soft tech look\",\n    \"playful volume modeling\"\n  ]\n}",
+        "根据以下 JSON 对附加的图像进行重新纹理化\n{\n  \"style_name\": \"Playful Chunky 3D Aesthetic\",\n  \"retexture_mode\": \"stylized_3d_overlay\",\n\"对象分析\": {\n\"保留轮廓\": true,\n\"几何敏感映射\": true,\n\"细节保留\": \"中等 — 侧重于关键形态和比例\"\n  },\n\"材料属性\": {\n    \"基础材料\": [\"柔软磨砂塑料\", \"弹性聚合物\"],\n    \"表面细节\": [\n\"圆润的边缘和膨胀的体积\",\n\"光滑、玩具般的表面\",\n\"极少的接缝线\"\n    ]\n  },\n\"lighting\": {\n    \"type\": \"工作室漫射光\",\n    \"intensity\": \"中等\",\n\"阴影\": \"柔和的基础阴影\",\n    \"高光行为\": \"曲线和凸起表面的柔和光泽\"\n  },\n  \"配色方案\": {\n\"主色调\": [\" #f6f6f6 \", \" #3a3a3a \", \" #f05423 \"],\n    \"强调色\": [\" #ff875d \", \" #b0b0b0 \", \" #f3f3f3 \"]\n  },\n  \"背景\": {\n\"color\": \" #f9f9f9 \",\n    \"type\": \"solid\",\n    \"texture\": \"none\"\n  },\n\"风格标签\": []\n\"3D 卡通写实风格\"\n\"UI 图标包美学\"\n\"膨胀极简主义\"\n\"柔和科技感\",\n\"俏皮体积建模\"\n  ]\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "cartoon",
+        "minimalist",
+        "toy",
+        "ui",
+        "vehicle"
+      ],
+      "coverImage": "images/242.png"
+    },
+    {
+      "id": 241,
+      "slug": "prompt-241",
+      "title": "9格Q版风格贴纸",
+      "source": {
+        "name": "@松果先森",
+        "url": "https://x.com/songguoxiansen/status/1950726378342801853"
+      },
+      "images": [
+        "images/241.png"
+      ],
+      "prompts": [
+        "Create a 3D kawaii 10-16 canvas featuring nine chibi-style stickers in various outfits, poses, and expressions. Use the uploaded attachment image. Each sticker has a white border and includes a speech bubble with regular use phrases. Set on a soft white-to-pastel blue gradient background for a fun, positive vibe, perfect for WhatsApp app use.",
+        "创建一幅尺寸为 10-16 的 3D 可爱风格画布，其中包含 9 个 Q 版风格贴纸。这些贴纸要采用不同的服装、姿势和表情，使用已经上传的附件图片。每个贴纸都要有白色边框，且包含一个带有日常用语的 speech 气泡。背景设置为柔和的白到淡蓝色渐变，营造出有趣、积极的氛围，非常适合在 WhatsApp 应用中使用。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "fashion",
+        "paper-craft"
+      ],
+      "coverImage": "images/241.png"
+    },
+    {
+      "id": 240,
+      "slug": "prompt-240",
+      "title": "定制的枕头",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1944487528704418041"
+      },
+      "images": [
+        "images/240.jpeg",
+        "images/240-2.jpeg"
+      ],
+      "prompts": [
+        "Create a high-resolution 3D render of the [BRAND] logo designed as an inflatable, puffy object. The logo should appear soft, rounded, and air-filled – like a plush balloon or blow-up toy. Use a smooth, matte texture with subtle fabric creases and stitching to emphasize the inflatable look. Position the logo at a 45-degree angle to highlight depth and realism. Place the final result on a couch in a stylish living room with furniture and decor that matches the iconic colors of the [BRAND] logo. Output dimension: 1080x1080.",
+        "创建一个高分辨率的 3D 渲染图，将[BRAND]标志设计成一个充气、蓬松的物体。标志应看起来柔软、圆润、充气——像一个毛绒气球或充气玩具。使用光滑的哑光纹理，带有细微的布料褶皱和缝线，以强调充气效果。将标志以 45 度角摆放，以突出深度和真实感。将最终结果放置在风格时尚的客厅沙发上，家具和装饰与[BRAND]标志的标志性颜色相匹配。输出尺寸：1080x1080。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "interior",
+        "logo",
+        "toy"
+      ],
+      "coverImage": "images/240.jpeg"
+    },
+    {
+      "id": 239,
+      "slug": "prompt-239",
+      "title": "沙滩胶囊城市",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1944386743865622718"
+      },
+      "images": [
+        "images/239.jpeg",
+        "images/239-2.jpeg"
+      ],
+      "prompts": [
+        "A vibrant, hyper-realistic miniature of [CITY] inside a transparent capsule lying on a sandy beach. The capsule is half [COLOR] (matching [COUNTRY]’s flag) with [CITY] written in white text on the colored section. Inside the capsule: iconic landmarks of [CITY], beautiful water canals or streets, small detailed boats or cars, sunny bright lighting, cinematic depth of field, dreamy atmosphere, ocean waves in the background.",
+        "一个充满活力的、超写实的[CITY]微缩模型，放置在一个透明胶囊内，躺在沙滩上。胶囊一半是[COLOR]色（与[COUNTRY]的国旗相匹配），彩色部分上用白色文字写着[CITY]。胶囊内部：[CITY]的标志性地标、美丽的运河或街道、小巧精致的船只或汽车、阳光明媚的光线、电影般的景深、梦幻般的氛围、背景中的海浪。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "logo",
+        "vehicle"
+      ],
+      "coverImage": "images/239.jpeg"
+    },
+    {
+      "id": 238,
+      "slug": "prompt-238",
+      "title": "用花朵美化你的产品",
+      "source": {
+        "name": "@Kerroudjm",
+        "url": "https://x.com/Kerroudjm/status/1944730614323671129"
+      },
+      "images": [
+        "images/238.png",
+        "images/238-2.jpeg"
+      ],
+      "prompts": [
+        "A high-end editorial photo of (PRODUCT NAME OR IMAGE) placed on a white marble pedestal, resting on champagne-colored silk. It is surrounded by pastel flowers whose type and color naturally harmonize with the product’s primary colors (COLOR PALETTE) — complementing and enhancing its tones. Soft natural light from the upper left. 3D realism, luxury product photography, shallow depth of field, 1:1 format.",
+        "(产品名称或图片)放置在白色大理石底座上，休息在香槟色丝绸上，的高端编辑照片。它被淡色花朵环绕，其类型和颜色自然与产品的主要颜色（调色板）协调——补充并增强其色调。来自左上方的柔和自然光。3D 现实主义，奢华产品摄影，浅景深，1:1 格式。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/238.png"
+    },
+    {
+      "id": 237,
+      "slug": "prompt-237",
+      "title": "电影镜头拍摄",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1944796547587125663"
+      },
+      "images": [
+        "images/237.png",
+        "images/237-2.jpeg"
+      ],
+      "prompts": [
+        "Cinematic shot of [detailed character description], shot from [camera angle], [lighting type], [color palette], shot at close range, 35mm film grain, wide angle lens, f2.0 bokeh, shallow depth of field.",
+        "电影镜头拍摄[详细角色描述]，从[相机角度]拍摄，[灯光类型]，[色彩搭配]，近距离拍摄，35mm 胶片颗粒，广角镜头，f2.0 浅景深，浅景深。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character"
+      ],
+      "coverImage": "images/237.png"
+    },
+    {
+      "id": 236,
+      "slug": "prompt-236",
+      "title": "直升机品牌广告",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1944724068982211044"
+      },
+      "images": [
+        "images/236.jpeg",
+        "images/236-2.jpeg"
+      ],
+      "prompts": [
+        "Create a hyper-realistic, square 1:1 image featuring a small helicopter flying through a bright blue sky with fluffy white clouds and a subtle lens flare. The helicopter is painted in the signature colors and graphics of [BRAND]. It is carrying a giant product from [BRAND] hanging below. The composition has the look and feel of a clean, playful (or premium, futuristic) advertisement. At the bottom, include the [BRAND] logo and a small slogan like [BRAND SLOGAN] in a stylish font. 1080x1080 dimension.",
+        "创作一张超写实的 1:1 方形图像，展现一架小型直升机在明亮的蓝天中飞行，周围有蓬松的白云和微妙的镜头眩光。直升机涂装着[BRAND]的标志性颜色和图案。它下方悬挂着一个来自[BRAND]的巨大产品。整个构图具有干净、俏皮（或高端、未来感）的广告风格。在底部，包含[BRAND]的标志和一句简短的风格化标语，如[BRAND SLOGAN]。尺寸为 1080x1080。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "futuristic",
+        "logo",
+        "nature",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/236.jpeg"
+    },
+    {
+      "id": 235,
+      "slug": "prompt-235",
+      "title": "讽刺版的你",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1944678797128708369"
+      },
+      "images": [
+        "images/235.jpeg",
+        "images/235-2.jpeg"
+      ],
+      "prompts": [
+        "Based on your understanding of my personality and past interactions, create a humorous and satirical image that teases me in a playful way. The image must have comedic features, using exaggerated expressions or surreal visual metaphors. Artistic style: cartoon or caricature with high contrast and expressive details. The goal is to amuse, not insult. Ensure the satire is clever and mindful.",
+        "根据您对我的个性和过去互动的理解，创建一个幽默、讽刺的图像，以俏皮的方式嘲笑我。图像必须具有喜剧特征，使用夸张的表情或超现实的视觉隐喻。艺术风格：具有高对比度和富有表现力的细节的卡通或漫画。目标是笑，而不是侮辱。确保讽刺是聪明和有意识的。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "vehicle"
+      ],
+      "coverImage": "images/235.jpeg"
+    },
+    {
+      "id": 234,
+      "slug": "prompt-234",
+      "title": "产品成为霓虹灯下的梦想",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1944334293297246692"
+      },
+      "images": [
+        "images/234.jpeg",
+        "images/234-2.jpeg"
+      ],
+      "prompts": [
+        "a surreal-realistic digital artwork of a product from the brand [Brand name]. The product should be glowing with neon outlines, stylized like a high-contrast 3D render. Place it in a dreamlike environment inspired by the brand’s identity, color scheme, and culture. Use soft shadows, deep blacks, and intense lighting for dramatic effect.",
+        "[Brand name] 品牌商品的超现实主义写实数字艺术作品。产品应该闪耀着霓虹灯轮廓，像高对比度的3D渲染一样风格化。将其放置在受品牌身份、配色方案和文化启发的梦幻般的环境中。使用柔和的阴影、深黑色和强烈的光照来获得戏剧性的效果。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "neon",
+        "product"
+      ],
+      "coverImage": "images/234.jpeg"
+    },
+    {
+      "id": 233,
+      "slug": "prompt-233",
+      "title": "超现实鸟类幻想",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1944700655249068043"
+      },
+      "images": [
+        "images/233.png",
+        "images/233-2.jpeg"
+      ],
+      "prompts": [
+        "A highly detailed and surreal depiction of a mythical bird creature. It has the elegant, colorful body of a butterfly, with vibrant symmetrical wing patterns. Its head is that of a majestic elephant, complete with large ears, a long curling trunk, and ivory tusks, giving it a powerful and ancient aura. A long, spotted giraffe neck connects the body and the head, rising high with grace. The wings are enormous eagle wings, fully extended with dramatic feathers in motion. Its tail is an iridescent peacock tail, fanned out in full display like royal plumage. The creature stands in an enchanted misty forest, bathed in ethereal light and surrounded by glowing particles. Ultra-realistic, cinematic lighting, fantasy atmosphere, hyper-detailed concept art",
+        "对神话鸟类生物的高度详细和超现实的描绘。它拥有优雅、多彩的蝴蝶身体，带有充满活力、对称的翅膀图案。它的头是一头雄伟的大象，长着大耳朵、长长的卷曲的鼻子和象牙，赋予它强大而古老的光环。长长的斑点长颈鹿脖子连接身体和头部，优雅地高高耸立。翅膀是巨大的鹰翅膀，完全伸展，羽毛在运动中戏剧性。它的尾巴是一条彩虹色的孔雀尾巴，像皇家羽毛一样呈扇形展开。这个生物站在一片迷人的迷雾森林中，沐浴在空灵的光芒中，周围环绕着发光的粒子。超逼真的电影般的照明、奇幻的氛围、超详细的概念艺术"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "fantasy"
+      ],
+      "coverImage": "images/233.png"
+    },
+    {
+      "id": 232,
+      "slug": "prompt-232",
+      "title": "胶囊从透明的药瓶中倾倒",
+      "source": {
+        "name": "@fy360593",
+        "url": "https://x.com/fy360593/status/1944782534128419179"
+      },
+      "images": [
+        "images/232.jpeg",
+        "images/232-2.jpeg"
+      ],
+      "prompts": [
+        "Hyper-realistic poster, 1080x1080. Small glossy/glass capsules spilling from a transparent medicine bottle onto a wet surface. Each capsule features [white]/[red] plastic and transparent glass, with [KFC] logo and a floating 3D icon inside. Strong reflections, studio lighting, water droplets, soft elegant background, DSLR photo realism.",
+        "超写实的海报，1080x1080。小型的光亮/玻璃胶囊从透明的药瓶中倾倒在湿润的表面上。每个胶囊都带有[白色]/[红色]塑料和透明玻璃，内有[KFC]标志和一个悬浮的 3D 图标。强烈的反光，工作室灯光，水滴，柔和优雅的背景，DSLR 照片真实性。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "logo",
+        "photography",
+        "poster"
+      ],
+      "coverImage": "images/232.jpeg"
+    },
+    {
+      "id": 231,
+      "slug": "prompt-231",
+      "title": "形状为生日气球文字",
+      "source": {
+        "name": "@Anima_Labs",
+        "url": "https://x.com/Anima_Labs/status/1945050362152427924"
+      },
+      "images": [
+        "images/231.png"
+      ],
+      "prompts": [
+        "Create a hyper-realistic 3D rendering of balloon letters forming the word [WOW]. Each letter should look like a shiny, inflatable mylar balloon with a bold printed pattern. Use a mix of textures such as [checkered print, color grids, polka dots, or glossy metallic black]. The balloons should be semi-reflective with realistic air volume, seams, wrinkles, and pressure points. Give each letter a distinct, playful surface design but keep the overall look cohesive. Use a soft pastel background, like [Orange color], to contrast the balloon textures. Lighting should create crisp reflections and soft shadows. The rendering must be photorealistic, fun, and vibrant — like a high-end visual for a creative pop-art birthday installation or fashion campaign.",
+        "创建一个超逼真的 3D 渲染效果，将气球字母组成单词 [WOW]。每个字母看起来都像是一个闪亮的充气镀铝气球，带有大胆印刷的图案。使用多种纹理，例如 [格子印刷、彩色网格、波点或光泽金属黑]。气球应该是半反射的，具有真实的空气体积、接缝、皱纹和压力点。给每个字母一个独特、有趣的表面设计，但保持整体外观协调一致。使用柔和的粉彩色背景，例如 [橙色]，以对比气球的纹理。光线应产生清晰的反射和柔和的阴影。渲染效果必须是照片级的逼真、有趣且充满活力——就像创意波普艺术生日装置或时尚活动的高端视觉效果。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "fashion",
+        "photography"
+      ],
+      "coverImage": "images/231.png"
+    },
+    {
+      "id": 230,
+      "slug": "prompt-230",
+      "title": "可爱的卡通灵魂",
+      "source": {
+        "name": "@松果先森",
+        "url": "https://x.com/songguoxiansen/status/1945032571114402108"
+      },
+      "images": [
+        "images/230.jpeg",
+        "images/230-2.jpeg"
+      ],
+      "prompts": [
+        "A cute cartoon ghost is the absolute main subject of the picture. It has a pure white body with a smooth and rounded contour, and two simple black oval eyes, with no extra features. This ghost is floating quietly in the very center of the picture. The background is a pure, bright purple, creating a simple, modern, and friendly atmosphere. The composition is a centered close-up, and the aspect ratio is 1:1 square. There is no text in the entire image. The image style is typical flat design and vector art, minimalist, much like an app icon or a logo, characterized by clean lines and solid color blocks, without any gradients or textural details. The image quality required is high-resolution with clean, sharp edges. The overall feeling it gives is one of a cute, simple, and modern piece of digital art.",
+        "一个可爱的卡通幽灵是画面的绝对主体，它拥有纯白色的、轮廓圆润流畅的身体，以及两只简单的黑色椭圆形眼睛，没有任何多余的特征。这个幽灵安静地漂浮着，位于整个画面的正中央。画面背景是纯粹的亮紫色，营造出一种简洁、现代且友好的氛围。构图方式为居中特写，图片比例为1:1的正方形。整个画面没有任何文字。这幅图像是典型的扁平化设计（Flat design）和矢量艺术风格，极简主义，非常像一个App图标或logo，特点是线条干净利落，颜色是纯色块填充，无任何渐变或纹理细节。图像质量要求高分辨率，边缘清晰锐利，整体给人一种可爱、简洁、现代化的数字艺术感受。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "minimalist",
+        "vehicle"
+      ],
+      "coverImage": "images/230.jpeg"
+    },
+    {
+      "id": 229,
+      "slug": "prompt-229",
+      "title": "品牌快餐胶囊",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1944462797666123872"
+      },
+      "images": [
+        "images/229.jpeg"
+      ],
+      "prompts": [
+        "Create a hyper-realistic, stylish poster [1080x1080] aspect ratio featuring a horizontal tablet-capsule hovering above a surface covered in condensation and water droplets, with its shadow cast on the wet ground. One side of the capsule is transparent glass, while the other is glossy [BRAND COLORS] plastic, displaying the [BRAND] logo and name. Seamlessly floating inside the glass portion of the capsule is a photorealistic 3D model of the [BRAND LOGO OR ICON], perfectly centered and suspended in zero gravity. The glass and plastic surfaces showcase strong reflections, refractions, and environmental distortions. The background is a softly blurred, elegant light-toned setting. Use a dynamic perspective with a stylish camera angle, professional studio lighting, and ultra-high detail to make the image look like a DSLR-captured photograph with impeccable realism.",
+        "创建一个超逼真、时尚的海报[1080x1080]宽高比，展示一个水平平板胶囊悬浮在布满水汽和液滴的表面上，其影子投射在湿润的地面上。胶囊一侧是透明玻璃，另一侧是光泽[品牌颜色]塑料，显示[品牌]标志和名称。玻璃部分无缝漂浮着一张逼真的 3D 模型[品牌标志或图标]，完美居中并悬浮在零重力中。玻璃和塑料表面展现出强烈的反射、折射和环境扭曲。背景是柔和模糊、优雅浅色调的设置。使用动态视角和时尚的相机角度，结合专业工作室灯光和超高清细节，使图像看起来像是一张由单反相机拍摄的真实照片，具有无懈可击的真实感。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "food",
+        "landscape",
+        "logo",
+        "photography",
+        "poster"
+      ],
+      "coverImage": "images/229.jpeg"
+    },
+    {
+      "id": 228,
+      "slug": "prompt-228",
+      "title": "日本搞笑漫画风格插画",
+      "source": {
+        "name": "@fy360593",
+        "url": "https://x.com/fy360593/status/1944708178266259689"
+      },
+      "images": [
+        "images/228.jpeg",
+        "images/228-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a Japanese gag manga style illustration. Use a high-contrast black-and-white color palette with bold linework and screentone (halftone) shading. Characters should have exaggerated facial expressions, cartoonish proportions (big head, small body), and comedic intensity. Include dynamic action lines or radiating background effects. The overall aesthetic should mimic retro manga from the 80s and 90s with humorous and intense emotion.",
+        "将这张图片转化为日本搞笑漫画风格插画。使用高对比度的黑白色彩搭配，粗犷的线条和网点（半色调）阴影。角色应有夸张的面部表情，卡通化的比例（大头小身），以及喜剧张力。包含动态动作线条或放射状背景效果。整体美学应模仿 80 年代和 90 年代的复古漫画，充满幽默和强烈的情感。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "illustration",
+        "retro",
+        "vehicle"
+      ],
+      "coverImage": "images/228.jpeg"
+    },
+    {
+      "id": 227,
+      "slug": "prompt-227",
+      "title": "糖果形状物品",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1944695498025173261"
+      },
+      "images": [
+        "images/227.png",
+        "images/227-2.jpeg"
+      ],
+      "prompts": [
+        "A glossy candy-shaped perfume bottle resting on an open book, soft morning light, delicate shadows, dreamy bokeh background with iridescent cellophane wrapping. The candy design is inspired by [YOUR STYLE]",
+        "一个闪亮的糖果形状的香水瓶静置在一本打开的书上，柔和的晨光，细腻的阴影，梦幻的背景虚化效果，带有彩虹色透明膜包装。糖果设计灵感来源于[你的风格]"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/227.png"
+    },
+    {
+      "id": 226,
+      "slug": "prompt-226",
+      "title": "电影场景",
+      "source": {
+        "name": "@Dd41Giant",
+        "url": "https://x.com/Dd41Giant/status/1944402963855769744"
+      },
+      "images": [
+        "images/226.png",
+        "images/226-2.jpeg"
+      ],
+      "prompts": [
+        "Close-up. Overhead shot from an extremely high vantage point, extremely low grain with iso100 film shadows on a Lomo LC-A. Realistic depth of field. Artistic composition. Overall bluish tones. Beautiful light and shadows. The black floor with the projected image of the blue sky that fills the screen. A very beautiful small-faced Japanese film actress with wet showy hair in a black dress shirt sitting cross-legged on the floor. She is wearing a long red skirt. Shiny black hair. Long eyelashes. Bright skin. Beautiful shining eyes. A smiling face. On the floor next to the actress is a white model of Saturn. The picture looks like a scene from a movie.",
+        "特写。从极高视角拍摄的上视图，使用 Lomo LC-A 相机拍摄，ISO100 胶片，颗粒感极低，阴影真实。艺术构图。整体偏蓝色调。光影美丽。黑色地板上投射着充满屏幕的蓝色天空图像。一位非常美丽的日本小脸女演员，穿着黑色衬衫，盘腿坐在地板上，头发湿漉漉地显眼，穿着长红色裙子。闪亮的黑发。长长的睫毛。明亮肌肤。美丽的闪亮眼睛。微笑的面容。女演员旁边的地板上有一个白色的土星模型。这张照片看起来像电影中的一个场景。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "landscape"
+      ],
+      "coverImage": "images/226.png"
+    },
+    {
+      "id": 225,
+      "slug": "prompt-225",
+      "title": "时尚的胶囊海报",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1944435018203296063"
+      },
+      "images": [
+        "images/225.jpeg"
+      ],
+      "prompts": [
+        "Create a hyper-realistic, stylish poster [1080x1080] aspect ratio featuring a horizontal tablet-capsule hovering above a surface covered in condensation and water droplets, with its shadow cast on the wet ground. One side of the capsule is transparent glass, while the other is glossy [COLOR/DESIGN] plastic, displaying the [BRAND] logo and name. Seamlessly floating inside the glass portion of the capsule is a photorealistic 3D model of the [LOGO], perfectly centered and suspended in zero gravity. The glass and plastic surfaces showcase strong reflections, refractions, and environmental distortions. The background is a softly blurred, elegant light-toned setting. Use a dynamic perspective with a stylish camera angle, professional studio lighting, and ultra-high detail to make the image look like a DSLR-captured photograph with impeccable realism.",
+        "创作一张超逼真、时尚的海报[1080x1080]宽高比，展示一个水平放置的平板胶囊悬浮在布满水汽和水滴的表面上，其影子投射在湿润的地面上。胶囊的一面是透明玻璃，另一面是光泽塑料[颜色/设计]，显示[品牌]标志和名称。在胶囊的玻璃部分中，一个逼真的 3D 模型[标志]无缝漂浮，完美居中并悬浮在零重力中。玻璃和塑料表面展现出强烈的反射、折射和环境扭曲。背景是一个柔和模糊、优雅浅色调的设置。使用动态视角和时尚的相机角度，结合专业工作室灯光和超高清细节，使图像看起来像是一张由单反相机拍摄的真实照片，具有无懈可击的真实感。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "logo",
+        "photography",
+        "poster"
+      ],
+      "coverImage": "images/225.jpeg"
+    },
+    {
+      "id": 224,
+      "slug": "prompt-224",
+      "title": "舒适的周末从这里开始",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1944368117116796955"
+      },
+      "images": [
+        "images/224.png",
+        "images/224-2.png"
+      ],
+      "prompts": [
+        "retexture the image attached based on the json below:\n{\n  \"style_name\": \"Soft Minimal 3D Plastic\",\n  \"retexture_mode\": \"shape_lock\",\n  \"object_analysis\": {\n    \"preserve_silhouette\": true,\n    \"geometry_sensitive_mapping\": true,\n    \"detail_retention\": \"flatten complex details into simplified geometry blocks\"\n  },\n  \"material_properties\": {\n    \"base_material\": [\n      \"smooth matte plastic\",\n      \"metallic edge trim with satin finish\",\n      \"semi-reflective black screen surface\"\n    ],\n    \"surface_details\": [\n      \"subtle color gradient\",\n      \"rounded bevels and corners\",\n      \"soft transition between surfaces\"\n    ]\n  },\n  \"lighting\": {\n    \"type\": \"soft gradient ambient light\",\n    \"shadows\": \"minimal, soft-edged shadows\",\n    \"highlights\": \"diffused, low-intensity reflections\"\n  },\n  \"background\": {\n    \"color\": \"pastel gradient (blue to cream)\",\n    \"texture\": \"smooth and untextured\",\n    \"elements\": \"clean background with no added geometry\"\n  },\n  \"rendering\": {\n    \"style\": \"isometric 3D render\",\n    \"resolution\": \"high, with slight bloom\",\n    \"focus\": \"central object, no depth blur\"\n  },\n  \"color_palette\": {\n    \"primary\": [\"cool grey\", \"steel blue\", \"soft charcoal\"],\n    \"accents\": [\"light lavender\", \"pastel yellow\"]\n  }\n}",
+        "根据以下 JSON 重新纹理附加的图像：\n{\n\"style_name\": \"柔和极简 3D 塑料风格\",\n  \"retexture_mode\": \"形状锁定\",\n  \"object_analysis\": {\n    \"preserve_silhouette\": true,\n\"geometry_sensitive_mapping\": true,\n    \"detail_retention\": \"将复杂的细节简化为简化的几何块\"\n  },\n  \"material_properties\": {\n\"base_material\": [\n\"光滑磨砂塑料\"，\n\"金属边缘饰条，缎面处理\"，\n\"半反射黑色屏幕表面\"\n],\n\"表面细节\": [\n\"微妙的颜色渐变\"，\n\"圆润的斜角和边角\"，\n\"表面之间的柔和过渡\"\n    ]\n  },\n\"lighting\": {\n\"类型\": \"柔和渐变环境光\",\n    \"阴影\": \"极少，边缘柔和的阴影\",\n    \"高光\": \"弥散，低强度的反射\"\n  },\n\"背景\": {\n    \"颜色\": \"柔和渐变（蓝色到奶油色）\",\n    \"纹理\": \"光滑无纹理\",\n    \"元素\": \"干净背景，无添加几何图形\"\n  },\n\"渲染\": {\n\"风格\": \"等距 3D 渲染\",\n\"分辨率\": \"高，略带轻微泛光\"\n\"focus\": \"中心对象，无深度模糊\"\n  },\n  \"color_palette\": {\n    \"primary\": [\"冷灰色\", \"钢蓝色\", \"柔和的炭黑色\"],\n\"accents\": [\"浅薰衣草色\", \"淡黄色\"]\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "minimalist"
+      ],
+      "coverImage": "images/224.png"
+    },
+    {
+      "id": 223,
+      "slug": "prompt-223",
+      "title": "惊人的外骨骼图像",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1944067498187665507"
+      },
+      "images": [
+        "images/223.jpeg",
+        "images/223-2.jpeg"
+      ],
+      "prompts": [
+        "a futuristic 3D-rendered [object] made of translucent [color] inner structure encased in a smooth white exoskeleton with organic holes and flowing biomorphic patterns, floating in a minimal soft gray background, high contrast lighting, hyperrealistic materials, octane render, modern digital sculpture",
+        "一个未来派的 3D 渲染[物体]，具有半透明的内部结构，被光滑的白色外骨骼包裹，外骨骼上有有机的孔洞和流动的仿生图案，悬浮在极简的浅灰色背景中，高对比度光照，超写实材质，Octane 渲染，现代数字雕塑"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "minimalist",
+        "sculpture"
+      ],
+      "coverImage": "images/223.jpeg"
+    },
+    {
+      "id": 222,
+      "slug": "prompt-222",
+      "title": "宝石渲染风格",
+      "source": {
+        "name": "@alban_gz",
+        "url": "https://x.com/alban_gz/status/1944033327767236869"
+      },
+      "images": [
+        "images/222.jpeg"
+      ],
+      "prompts": [
+        "Apply the parameters of the JSON provided to [insert image]\n\n{\n  \"name\": \"Gemstone Render\",\n  \"object\": {\n    \"type\": \"auto\",\n    \"detected_color\": \"auto\",\n    \"form\": \"realistic, natural form preserved\",\n    \"material\": \"crystal or faceted gemstone glass\",\n    \"surface\": \"precision-cut facets, sharp reflections\",\n    \"transparency\": \"high clarity with light refraction\",\n    \"internal_features\": \"color depth, internal shimmer, and light dispersion\"\n  },\n  \"color_and_light\": {\n    \"primary_color\": \"{detected_color}\",\n    \"highlight_effects\": \"specular highlights, gemstone brilliance, caustics\",\n    \"lighting_setup\": \"studio lighting with white or soft background\",\n    \"metallic_accents\": {\n      \"enabled\": true,\n      \"material\": \"gold or chrome\",\n      \"application\": \"rim, stem, or edge detailing\"\n    }\n  },\n  \"style\": {\n    \"artistic_style\": [\n      \"photorealistic 3D render\",\n      \"Gemstone Render Style\",\n      \"luxury object visualization\"\n    ],\n    \"design_language\": [\n      \"faceted precision modeling\",\n      \"jewelry-like rendering\",\n      \"optical depth and brilliance\"\n    ]\n  },\n  \"technical_details\": {\n    \"render_engine\": [\n      \"Blender with Cycles\",\n      \"Cinema 4D + Redshift/Octane\"\n    ],\n    \"rendering_techniques\": [\n      \"physically-based rendering (PBR)\",\n      \"ray tracing\",\n      \"global illumination\"\n    ],\n    \"resolution\": \"ultra high-res (4K–8K)\",\n    \"post_processing\": [\n      \"subtle glow\",\n      \"enhanced reflections\",\n    \"color-preserving contrast boost\"\n    ]\n  },\n  \"prompt_template\": \"A 3D-rendered image of a {object} made of {detected_color} crystal, with intricate gemstone-like facets. It sparkles with internal reflections and sits on a clean studio background, blending realism with luxury design.\"\n}",
+        "将提供的 JSON 参数应用于[插入图片]\n\n{\n  \"名称\": \"宝石渲染\",\n  \"物体\": {\n    \"类型\": \"自动\",\n    \"检测到的颜色\": \"自动\",\n    \"形态\": \"逼真、自然形态得以保留\",\n    \"材质\": \"水晶或多面宝石玻璃\",\n    \"表面\": \"精密切割的刻面、清晰的反光\",\n    \"透明度\": \"高清晰度，带有光线折射\",\n    \"内部特征\": \"色彩深度、内部光泽和光线色散\"\n  },\n  \"颜色与光线\": {\n    \"主色调\": \"{detected_color}\",\n    \"高光效果\": \"镜面高光、宝石光泽、焦散效果\",\n    \"照明设置\": \"工作室照明，搭配白色或柔和背景\",\n    \"金属装饰\": {\n      \"启用\": true,\n      \"材质\": \"黄金或铬合金\",\n      \"应用位置\": \"边缘、柄部或侧边细节\"\n    }\n  },\n  \"风格\": {\n    \"艺术风格\": [\n      \"照片级写实3D渲染\",\n      \"宝石渲染风格\",\n      \"奢华物体可视化\"\n    ],\n    \"设计语言\": [\n      \"多面精密建模\",\n      \"珠宝式渲染\",\n      \"光学深度与光泽\"\n    ]\n  },\n  \"技术细节\": {\n    \"渲染引擎\": [\n      \"Blender搭配Cycles\",\n      \"Cinema 4D + Redshift/Octane\"\n    ],\n    \"渲染技术\": [\n      \"基于物理的渲染（PBR）\",\n      \"光线追踪\",\n      \"全局光照\"\n    ],\n    \"分辨率\": \"超高分辨率（4K–8K）\",\n    \"后期处理\": [\n      \"柔和光晕\",\n      \"增强的反光\",\n      \"保持色彩的对比度提升\"\n    ]\n  },\n  \"提示模板\": \"一张{物体}的3D渲染图像，由{detected_color}水晶制成，带有复杂的宝石般刻面。它内部反光闪耀，置于干净的工作室背景上，融合了写实感与奢华设计。\"\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/222.jpeg"
+    },
+    {
+      "id": 221,
+      "slug": "prompt-221",
+      "title": "钻石镶嵌风格",
+      "source": {
+        "name": "@alban_gz",
+        "url": "https://x.com/alban_gz/status/1944405761439756343"
+      },
+      "images": [
+        "images/221.jpeg",
+        "images/221-2.jpeg"
+      ],
+      "prompts": [
+        "Recreate this image using the parameters of the JSON provided.\n{\n  \"style_name\": \"Diamond-Encrusted Glamour\",\n  \"description\": \"Applies a hyper-realistic diamond-encrusted style to any object, logo, or shape. The surface of the subject is entirely covered with sparkling gemstones that reflect light with intense brilliance, creating a luxurious, eye-catching, and surreal look.\",\n  \"surface_texture\": {\n    \"material\": \"diamond-crystal\",\n    \"coating\": \"fully encrusted with multi-faceted diamonds\",\n    \"sparkle_intensity\": \"maximum\",\n    \"reflection_type\": \"specular and highly refractive\",\n    \"detail_density\": \"ultra-fine, micro-gem coverage with no gaps\",\n    \"light_refraction\": \"strong rainbow dispersion through facets\"\n  },\n  \"lighting\": {\n    \"light_source\": \"hard directional light\",\n    \"highlight_effects\": \"lens flares, sparkle flares on gem edges\",\n    \"shadow_type\": \"soft-edged, low-opacity shadows for contrast\",\n    \"specularity\": \"very high\",\n    \"reflection_sources\": \"ambient and direct highlights across the gem facets\"\n  },\n  \"background\": {\n    \"type\": \"minimalist solid color\",\n    \"color\": \"#B0C4DE\",\n    \"texture\": \"smooth matte\",\n    \"contrast_with_subject\": \"high contrast to enhance sparkle\",\n    \"depth\": \"subtle shadow under the object for floating effect\"\n  },\n  \"color_palette\": {\n    \"primary\": \"transparent white (diamond base)\",\n    \"secondary\": \"prismatic reflections (rainbow light dispersion)\",\n    \"accent\": \"metallic shimmer on edges (optional: gold or silver undertones)\"\n  },\n  \"camera\": {\n    \"angle\": \"slight top-down perspective\",\n    \"depth_of_field\": \"shallow (sharp focus on object, blurred background)\",\n    \"lens_effects\": [\"macro focus\", \"sparkle highlights\", \"light bloom\"]\n  },\n  \"style_keywords\": [\n    \"glamorous\",\n    \"luxury\",\n    \"crystal-covered\",\n    \"bling\",\n    \"hyper-detailed\",\n    \"sparkling\",\n    \"futuristic\",\n    \"eye-catching\",\n    \"surreal realism\",\n    \"fashion-inspired\"\n  ],\n  \"applicability\": {\n    \"usable_on\": [\"logos\", \"icons\", \"food items\", \"everyday objects\", \"fashion accessories\", \"typography\"],\n    \"visual_requirements\": [\"well-defined silhouette\", \"clean shapes for gem placement\"],\n    \"scalability\": \"best results on medium to large subjects for detailed sparkle\"\n  }\n}",
+        "使用提供的 JSON 参数重新创建此图像。\n\n{\n\"style_name\": \"钻石镶嵌奢华风格\",\n  \"description\": \"将超逼真的钻石镶嵌风格应用于任何物体、标志或形状。主体的表面完全覆盖着闪闪发光的宝石，这些宝石以强烈的亮度反射光线，营造出奢华、引人注目和超现实的效果。\",\n  \"surface_texture\": {\n    \"material\": \"钻石水晶\",\n\"涂层\": \"完全镶嵌有多面钻石\",\n\"闪耀强度\": \"最大\",\n\"反射类型\": \"镜面和高折射率\",\n\"细节密度\": \"超精细，微宝石覆盖，无间隙\"\n\"light_refraction\": \"通过切面产生强烈的彩虹色散\"\n  },\n  \"lighting\": {\n    \"light_source\": \"硬直射光源\",\n\"高光效果\": \"镜头眩光，宝石边缘的闪光眩光\",\n    \"阴影类型\": \"柔和边缘，低不透明度的阴影以形成对比\",\n    \"光泽度\": \"非常高\",\n    \"反射源\": \"宝石切面的环境光和直接高光\"\n  },\n\"background\": {\n    \"type\": \"极简纯色\",\n    \"color\": \" #B0C4DE \",\n\"纹理\": \"光滑磨砂质感\",\n\"与主体对比度\": \"高对比度以增强闪耀效果\",\n\"深度\": \"物体下方微妙阴影以产生悬浮效果\"\n  },\n\"color_palette\": {\n    \"primary\": \"透明白色（钻石基底）\",\n    \"secondary\": \"棱镜反射（彩虹光散）\",\n    \"accent\": \"边缘金属光泽（可选：金色或银色底色）\"\n  },\n\"camera\": {\n    \"angle\": \"略微俯视角度\",\n    \"depth_of_field\": \"浅景深（物体清晰，背景模糊）\",\n\"镜头效果\": [\"微距对焦\", \"闪烁高光\", \"光晕\"]\n  },\n  \"风格关键词\": [\n    \"迷人\",\n\"奢侈\",\n\"水晶覆盖的\",\n\"闪亮\",\n\"超精细的\",\n\"闪闪发光的\",\n\"未来感的\",\n\"引人注目的\",\n\"超现实现实主义\",\n\"受时尚启发的\"\n  ],\n  \"适用性\": {\n    \"可用于\": [\"标志\", \"图标\", \"食品项目\", \"日常用品\", \"时尚配饰\", \"字体\"],\n\"视觉要求\": [\"轮廓清晰\", \"宝石放置的形状干净\"],\n    \"可扩展性\": \"在中等至大型对象上获得最佳效果，以展现细节闪烁\"\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "fashion",
+        "food",
+        "futuristic",
+        "logo",
+        "minimalist",
+        "typography"
+      ],
+      "coverImage": "images/221.jpeg"
+    },
+    {
+      "id": 220,
+      "slug": "prompt-220",
+      "title": "3D店铺渲染图",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1943242512820273451"
+      },
+      "images": [
+        "images/220.jpeg"
+      ],
+      "prompts": [
+        "Ultra-realistic 3D render of a cute, miniature [BRAND NAME] storefront building. Designed using the brand’s signature style and color palette. Features a clean, modern exterior with large glass windows and a glowing 3D [BRAND NAME] logo sign on the front. Includes subtle branded props inside the store. Background matches the brand’s identity — clean, relevant, and atmospheric. Slight isometric angle, warm lighting, soft shadows, and centered composition.",
+        "逼真的 3D 渲染图，展示了一个可爱、迷你版的[品牌名称]店铺建筑。采用品牌的标志性风格和色彩搭配设计。外部设计简洁现代，配有大型玻璃窗，正面有一个发光的 3D[品牌名称]标志。店内包含细微的品牌道具。背景与品牌身份相匹配——干净、相关且富有氛围。略微的等距角度，温暖的照明，柔和的阴影，居中构图。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "branding",
+        "logo",
+        "nature"
+      ],
+      "coverImage": "images/220.jpeg"
+    },
+    {
+      "id": 219,
+      "slug": "prompt-219",
+      "title": "冬日国家",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1942870693625897385"
+      },
+      "images": [
+        "images/219.png",
+        "images/219-2.png"
+      ],
+      "prompts": [
+        "A super detailed, realistic snow globe containing the essence of [Country Name]. Inside the globe: miniature snowy landscapes, iconic landmarks, cultural symbols, and natural elements representing [Country Name], rendered with extreme realism and rich textures. Delicate falling snow creates a magical, atmospheric effect inside the globe. The background is clean and softly lit to focus entirely on the globe. The image is 1:1 aspect ratio. At the bottom of the image, the text “[Country Name]” is clearly written in an elegant serif font",
+        "一个超级精细、逼真的雪球，包含着[国家名称]的精髓。球内：微型的雪景、标志性建筑、文化符号以及代表[国家名称]的自然元素，以极致的逼真感和丰富的纹理呈现。细腻的飘落雪花在球内营造出神奇的、充满氛围的效果。背景干净且柔和照明，完全聚焦于雪球。图像为 1:1 的宽高比。图像底部，用优雅的衬线字体清晰地书写着“[国家名称]”"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "landscape",
+        "logo",
+        "nature",
+        "typography"
+      ],
+      "coverImage": "images/219.png"
+    },
+    {
+      "id": 218,
+      "slug": "prompt-218",
+      "title": "超现实的黑白彩色页面",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1942942055740678318"
+      },
+      "images": [
+        "images/218.jpeg"
+      ],
+      "prompts": [
+        "Create a psychedelic black and white coloring page featuring melting [SUBJECT] in the center, surrounded by large, playful shapes and smooth flowing patterns. The background includes whimsical and surreal elements such as sunflowers with eyes, melting eyeballs, melting hearts, melting mushrooms, clouds, and stars. Use bold, clean outlines and fully enclosed shapes to create distinct sections for easy coloring. Avoid excessive fine detail or clutter. Keep the composition open, spacious, and fun. Square aspect ratio with a white background. No text or color.",
+        "创建一个超现实的黑白彩色页面，中心是融化的[主题]，周围有大型、有趣的形状和流畅的图案。背景包括诸如带眼睛的向日葵、融化的眼球、融化的心形、融化的蘑菇、云朵和星星等奇幻和超现实元素。使用粗犷、干净的轮廓和完全封闭的形状来创建易于上色的不同区域。避免过多的精细细节或杂乱。保持构图开放、宽敞和有趣。方形长宽比，白色背景。无文字或颜色。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "fantasy",
+        "interior"
+      ],
+      "coverImage": "images/218.jpeg"
+    },
+    {
+      "id": 217,
+      "slug": "prompt-217",
+      "title": "卡通现代风格插画",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1942867064378573293"
+      },
+      "images": [
+        "images/217.png",
+        "images/217-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a Cartoon Modern Style illustration, inspired by classic UPA animation like Mr. Magoo and The Jetsons.\nRedesign the character using flat, geometric shapes: ovals, rectangles, simple curves and angles. Avoid realistic proportions — the design should be stylized and abstract.\nUse a limited color palette, preferably soft pastels or bold contrasts (e.g. mint green, salmon, sky blue, mustard yellow), with flat tones and no gradients.\nSimplify facial features and body structure to be iconic and minimalist — large heads, small limbs, expressive poses, but with minimal detail.\nThe background should be minimal or symbolic, using basic shapes or abstract scenery (floating stairs, blocky furniture, stylized trees or stars).\nThe final image should look like a frame from a 1950s or 1960s modernist cartoon — playful, graphic, and highly stylized.",
+        "将这张图片转换为卡通现代风格插画，灵感来源于经典的 UPA 动画，如《摩根先生》和《太空家庭》。\n使用扁平的几何形状重新设计角色：椭圆形、矩形、简单的曲线和角度。避免真实比例——设计应该是风格化的和抽象的。\n使用有限的调色板，最好是柔和的粉彩色或鲜明的对比色（例如薄荷绿、三文鱼色、天空蓝、芥末黄），使用扁平色调且没有渐变。\n简化面部特征和身体结构，使其具有标志性且极简——大头、小四肢、富有表现力的姿势，但细节极少。\n背景应极简或象征性，使用基本形状或抽象场景（漂浮的楼梯、积木家具、风格化的树木或星星）。\n最终图像应像 1950 年代或 1960 年代现代主义卡通的一帧——活泼、图形化且高度风格化。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "illustration",
+        "landscape",
+        "logo",
+        "minimalist",
+        "vehicle"
+      ],
+      "coverImage": "images/217.png"
+    },
+    {
+      "id": 216,
+      "slug": "prompt-216",
+      "title": "穿越梦境迷宫",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1942850557548388499"
+      },
+      "images": [
+        "images/216.png",
+        "images/216-2.jpeg"
+      ],
+      "prompts": [
+        "[Character] sprinting past dream elements, Storybook illustration, Maze of floating doors, clocks, and whispers, Lantern glow and ambient sparkle trails, [Color1] and [Color2], Whimsical and fast-paced, Follow-cam style with trailing POV",
+        "[角色] 冲过梦境元素，故事书插画风格，漂浮的门、时钟和低语组成的迷宫，灯笼光芒和周围闪烁的轨迹，[颜色 1]和[颜色 2]，奇幻且节奏快速，跟随镜头风格，带有轨迹的 POV 视角"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fantasy",
+        "illustration"
+      ],
+      "coverImage": "images/216.png"
+    },
+    {
+      "id": 215,
+      "slug": "prompt-215",
+      "title": "Gorillaz风格",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1942586412920103180"
+      },
+      "images": [
+        "images/215.png",
+        "images/215-2.png"
+      ],
+      "prompts": [
+        "Restyle this image into a gritty Gorillaz-style illustration, bold thick black outlines, sharp angular edges, flat expressive lighting, stylized high-contrast shadows, dirty distressed surface textures, muted color palette: washed-out teals, olive greens, rusty reds, mustard yellows, dusty browns, raw grungy urban atmosphere, comic book flatness mixed with painterly grit, hand-drawn finish with faded gradients, graphic novel aesthetic\nwith a rebellious, animated tone, dark stylish tone, full of attitude.",
+        "将这张图片改造成硬朗的 Gorillaz 风格插画，粗犷的黑色轮廓线，尖锐的角边，平面化的表现性光照，风格化的高对比度阴影，脏污的磨损表面纹理，柔和的调色板：褪色的蓝绿色，橄榄绿，锈红色，芥末黄，尘土棕，原始的粗糙都市氛围，漫画书平面感与绘画性粗糙的混合，手绘效果带有褪色渐变，漫画小说美学带有叛逆、动画化的风格，暗黑时尚的调调，充满态度。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "illustration"
+      ],
+      "coverImage": "images/215.png"
+    },
+    {
+      "id": 214,
+      "slug": "prompt-214",
+      "title": "部分咬掉的糕点",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1942635640816034224"
+      },
+      "images": [
+        "images/214.jpeg",
+        "images/214-2.jpeg"
+      ],
+      "prompts": [
+        "A high-resolution, studio-lit macro photograph of a pastry shaped like a [SUBJECT], with a partial bite taken out, placed on a neutral matte surface with visible crumbs and soft shadows, highlighting texture and detail",
+        "一张高分辨率的、影棚照明的微距照片，展示一个形状像[主题]的糕点，部分咬掉，放在一个中性哑光表面上，有明显的面包屑和柔和的阴影，突出质感和细节"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "photography"
+      ],
+      "coverImage": "images/214.jpeg"
+    },
+    {
+      "id": 213,
+      "slug": "prompt-213",
+      "title": "3D蓬松的物体",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1942882098567618686"
+      },
+      "images": [
+        "images/213.jpeg"
+      ],
+      "prompts": [
+        "Transform the [BRAND NAME] logo into a hyper-realistic, 3D fluffy object. Keep the original shape and exact brand colors. Cover the entire surface in soft, detailed fur with a realistic hair texture. Use cinematic lighting to create subtle backlighting and soft shadows, making the logo appear tactile and surreal. Place the logo in the center of a clean black background, floating gently with a modern, stylish look. The style should feel cozy, playful, and visually striking. Render in ultra-high 4K resolution with photorealistic quality.",
+        "将[品牌名称]标志转化为超逼真、3D 蓬松的物体。保持原始形状和品牌的确切颜色。用柔软、细节丰富的毛皮覆盖整个表面，具有逼真的毛发纹理。使用电影感光效创造微妙的后光和柔和的阴影，使标志看起来有触感和超现实。将标志放在干净黑色背景的中心，轻轻漂浮，具有现代时尚感。风格应感觉温馨、俏皮、视觉上引人注目。以超高清 4K 分辨率渲染，具有照片级真实质量。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "logo",
+        "photography"
+      ],
+      "coverImage": "images/213.jpeg"
+    },
+    {
+      "id": 212,
+      "slug": "prompt-212",
+      "title": "品牌在悬浮平台上",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1942981383820845445"
+      },
+      "images": [
+        "images/212.png",
+        "images/212-2.png"
+      ],
+      "prompts": [
+        "A highly detailed cinematic advertisement scene featuring [TYPE OF ALCOHOL, BRAND], standing on a surreal floating platform that visually embodies its spirit. The platform is made of materials that represent the drink’s essence (e.g. sparkling crystals for champagne, rich dark wood for whiskey, frosted ice for vodka), with dramatic reflections and melting details dripping into a calm reflective water surface. A matching glass is filled with the drink, featuring artistic textures (ice, gems, swirling liquid). Soft, colorful sunset sky with dramatic clouds in the background, high-end luxury aesthetic, photorealistic, macro details, dreamy glow, premium product photography.",
+        "一个高度细致的影视广告场景，展示[酒类类型，品牌]，站在一个体现其精神的超现实悬浮平台上。平台由代表饮品本质的材料制成（例如香槟的闪亮水晶、威士忌的浓郁深色木材、伏特加的冰霜），戏剧性的倒影和融化的细节滴入平静的反射水面。一个匹配的玻璃杯装满了饮品，具有艺术纹理（冰块、宝石、旋转的液体）。柔和的彩色日落天空背景中有戏剧性的云朵，高端奢华美学，照片级真实感，宏观细节，梦幻般的光芒，高端产品摄影。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/212.png"
+    },
+    {
+      "id": 211,
+      "slug": "prompt-211",
+      "title": "灯泡中的城市",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1942976425281114576"
+      },
+      "images": [
+        "images/211.jpeg",
+        "images/211-2.jpeg"
+      ],
+      "prompts": [
+        "Create a hyper-realistic, stylish poster featuring a light bulb lying on wet urban asphalt. Inside the bulb, place a miniature version of [CITY] with its iconic landmarks. A sleek white 3D text of the city name ‘[CITY]’ should stand prominently in front of the bulb. The background is a softly blurred cityscape with neon lights reflecting on the bulb’s glass and the wet pavement. Add volumetric moonlight for depth and atmosphere. The image should look like a high-quality DSLR photograph with sharp details, cinematic lighting, and a moody, futuristic vibe.",
+        "创作一张超逼真、时尚的海报，展示一个躺在湿漉漉的城市柏油路面上的灯泡。在灯泡内部放置一个[CITY]的微缩版，并包含其标志性地标。在灯泡前方，应突出显示一个光滑的白色 3D 文字，写着城市名称‘[CITY]’。背景是柔和模糊的城市景观，霓虹灯光在灯泡的玻璃和湿滑的路面上映射。添加体积光以增强深度和氛围。图像应看起来像一张高质量的数码单反相机照片，具有清晰的细节、电影般的灯光和忧郁的未来感。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "landscape",
+        "logo",
+        "neon",
+        "photography",
+        "poster"
+      ],
+      "coverImage": "images/211.jpeg"
+    },
+    {
+      "id": 210,
+      "slug": "prompt-210",
+      "title": "90年代风格的摔跤人物",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1934287289154228450"
+      },
+      "images": [
+        "images/210.jpeg",
+        "images/210-2.jpeg"
+      ],
+      "prompts": [
+        "Product photography, a 1990's style WWF Wrestling Figurine package with the figurine wrestler in the package being [your character]. The figure features bright colors, a detailed character design,  white background with professional studio lighting.",
+        "产品摄影，一个 90 年代风格的 WWF 摔角人偶包装，包装中的人偶是[你的角色]。人偶色彩鲜艳，角色设计精细，背景为白色，配有专业工作室灯光。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "character",
+        "photography",
+        "portrait",
+        "product",
+        "toy"
+      ],
+      "coverImage": "images/210.jpeg"
+    },
+    {
+      "id": 209,
+      "slug": "prompt-209",
+      "title": "吃掉你的文字",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1935749368876867967"
+      },
+      "images": [
+        "images/209.jpeg",
+        "images/209-2.jpeg"
+      ],
+      "prompts": [
+        "Create the word “[WORD]” made entirely from its real texture and styled using the identity of the most iconic brand associated with it.\n\nThe word should:\n• Visually reflect the material (e.g. honey, chocolate, soda, candy).\n• Use the brand’s signature colors and typography.\n• Include the brand logo beneath the word.\n• Add a short slogan (3–4 words) matching the product’s vibe.\n• Be centered in a minimal background inspired by the product (e.g. breakfast table, soda splash, cookie tray).\n\n• Dimensions: 1:1\n• Style: clean, bold, product-focused\n• Render: ultra-HD, HDR, 8K",
+        "创建由其真实质感完全构成，并使用与其最具有标志性的品牌相联系的标识进行风格的“[单词]”。\n\n该单词应：\n• 视觉上反映材料（例如蜂蜜、巧克力、汽水、糖果）。\n• 使用该品牌的标志性颜色和字体。\n• 在文字下方包含品牌标志。\n• 添加一个与产品氛围相符的简短口号（3-4 个字）。\n• 居中放置在受产品启发的简约背景中（例如：早餐桌、汽水飞溅、饼干托盘）。\n\n• 尺寸：1:1\n• 风格：简洁、醒目、以产品为中心\n• 渲染：超高清、HDR、8K"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "food",
+        "logo",
+        "minimalist",
+        "nature",
+        "product",
+        "typography"
+      ],
+      "coverImage": "images/209.jpeg"
+    },
+    {
+      "id": 208,
+      "slug": "prompt-208",
+      "title": "逼真的产品照片",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1934250327693476182"
+      },
+      "images": [
+        "images/208.jpeg",
+        "images/208-2.jpeg"
+      ],
+      "prompts": [
+        "A realistic product photo of a [brand name] [bottle or jar] sculpted entirely from fresh [ingredient name], arranged perfectly to form the shape of the original packaging, including a detailed and accurate label on the front. The background is a clean, soft light gray with a natural wooden surface. Studio lighting, soft shadows, 1:1 square composition, professional product photography style, ultra-detailed textures, vibrant and glossy finish",
+        "一个逼真的产品照片，展示一个[品牌名称][瓶子或罐子]，完全由新鲜[原料名称]雕刻而成，完美排列形成原始包装的形状，包括前面详细且准确的标签。背景是干净柔和的浅灰色，带有自然木质表面。工作室灯光，柔和阴影，1:1 方形构图，专业产品摄影风格，超精细纹理，生动有光泽的表面。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "nature",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/208.jpeg"
+    },
+    {
+      "id": 207,
+      "slug": "prompt-207",
+      "title": "超现实的高冲击力的图像",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1925576114803749307"
+      },
+      "images": [
+        "images/207.jpeg",
+        "images/207-2.jpeg"
+      ],
+      "prompts": [
+        "Create a hyperrealistic, high-impact image of a [subject] suspended mid-air, captured at the peak of an explosive moment. Surround it with dynamic [particles/splashes/fragments] that enhance motion and energy. macro-level detail, bold rim lighting, and a vibrant [background color] to emphasize form, texture, and contrast, cinematic, modern, and visually striking. perfect for premium product campaigns.",
+        "创建一个超现实的、高冲击力的图像，展示一个[主题]在空中悬停，捕捉到爆炸性时刻的巅峰。用动态的[粒子/飞溅/碎片]围绕它，增强运动感和能量。宏观细节，大胆的边缘照明，以及充满活力的[背景颜色]，以强调形状、质感和对比度，电影般的、现代的、视觉上引人注目。非常适合高端产品活动。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "product"
+      ],
+      "coverImage": "images/207.jpeg"
+    },
+    {
+      "id": 206,
+      "slug": "prompt-206",
+      "title": "工业内部品牌广告",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1933698466577866902"
+      },
+      "images": [
+        "images/206.jpeg",
+        "images/206-2.jpeg"
+      ],
+      "prompts": [
+        "Create a hyperrealistic, surreal 1:1 advertisement for [Brand Name].\nTransform the product into a miniature industrial factory or laboratory from the inside.\nReveal detailed internal systems: pipes, workers, glowing fluids, steam, and machines — all functioning to reflect the product’s core purpose (energy, beauty, flavor, etc).\nKeep the outer product branding realistic and sharp.\nSet the background minimal and cinematic.\nAdd the brand logo at the top, and a short, powerful slogan at the bottom.\nStyle: studio-grade lighting, high contrast, photorealistic textures.",
+        "创建一个超现实、1:1 比例的品牌广告。\n将产品内部转化为微型工厂或实验室。\n展示详细的内部系统：管道、工人、发光的液体、蒸汽和机器——所有这些都运作起来，反映产品的核心功能（能量、美丽、风味等）。\n保持外层产品的品牌标识真实锐利。\n将背景设置得简约且电影感十足。\n在顶部添加品牌标志，底部添加一句简短有力的口号。\n风格：影棚级灯光，高对比度，照片级真实纹理。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "logo",
+        "minimalist",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/206.jpeg"
+    },
+    {
+      "id": 205,
+      "slug": "prompt-205",
+      "title": "以动物为灵感的品牌",
+      "source": {
+        "name": "@Kerroudjm",
+        "url": "https://x.com/Kerroudjm/status/1935037246182408301"
+      },
+      "images": [
+        "images/205.png"
+      ],
+      "prompts": [
+        "A high-quality studio photograph of a [BRAND + OBJECT] fully covered in ultra-realistic [ANIMAL] texture (e.g., fur, feathers, skin, or scales), placed against a soft neutral background. The object’s original shape, key design elements, and brand identity remain clearly visible beneath the animal’s organic surface. Integrate the official logo of the brand prominently into the composition. Automatically generate a compelling and brand-appropriate slogan that draws symbolic inspiration from the animal’s qualities and matches the tone of a premium advertising campaign. The image must feature clean composition, soft shadows, minimalist styling, professional lighting, and highly detailed textures—each hair, scale, or wrinkle should be visible in sharp detail. Format 1:1.",
+        "一张高品质的影棚照片，展示一个[品牌+物品]完全覆盖着超逼真的[动物]纹理（例如毛发、羽毛、皮肤或鳞片），放置在柔和的中性背景前。物品的原始形状、关键设计元素和品牌标识在动物的自然表面下依然清晰可见。将品牌的官方标志显著地融入构图。自动生成一个引人入胜且符合品牌调性的口号，从动物的品质中汲取象征性灵感，匹配高端广告活动的基调。图像必须具备整洁的构图、柔和的阴影、极简风格、专业的灯光和高度精细的纹理——每一根毛发、鳞片或皱纹都应在锐利的细节中清晰可见。格式 1:1。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "branding",
+        "logo",
+        "minimalist",
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/205.png"
+    },
+    {
+      "id": 204,
+      "slug": "prompt-204",
+      "title": "黑客帝国的绿色代码",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1920343010975551554"
+      },
+      "images": [
+        "images/204.jpeg",
+        "images/204-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a digital Matrix-style scene. The background and subject should be composed of cascading neon green code on a black backdrop, similar to the iconic Matrix digital rain. Use glowing green symbols (Japanese katakana, numbers, and Latin letters), with some motion blur and depth. Add subtle lighting effects to simulate screen glow and enhance the cyberpunk, high-tech atmosphere",
+        "将这张图像转化为数字《黑客帝国》风格场景。背景和主题应由倾泻而下的霓虹绿色代码组成，在黑色背景下，类似于标志性的《黑客帝国》数字雨。使用发光的绿色符号（日语假名、数字和拉丁字母），带有一些运动模糊和深度。添加微妙的光照效果来模拟屏幕辉光，增强赛博朋克、高科技氛围"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "landscape",
+        "logo",
+        "neon",
+        "sci-fi"
+      ],
+      "coverImage": "images/204.jpeg"
+    },
+    {
+      "id": 203,
+      "slug": "prompt-203",
+      "title": "3D表情符号头部",
+      "source": {
+        "name": "@TechieBySA",
+        "url": "https://x.com/TechieBySA/status/1942928111244394788"
+      },
+      "images": [
+        "images/203.jpeg"
+      ],
+      "prompts": [
+        "Generate a hyper-realistic 3D render of a [EMOJI🐱] as a floating animal head with plush toy aesthetics. The design should emphasize ultra-soft, long fur, playful cuteness, and a childlike charm. Use a straight-on camera angle with soft, diffused lighting to create a warm and inviting glow. Keep the background pure white for a clean, modern look. The color palette should be vibrant yet soothing, enhancing the toy-like appeal. Style: Ultra-detailed, whimsical, and hyper-cute, blending realism with a soft, plush texture for maximum visual impact.",
+        "生成一个超逼真的 3D 渲染效果，将[表情符号 🐱 ]设计成一个漂浮的动物头部，具有毛绒玩具的美学风格。设计应强调超柔软的长毛、俏皮可爱和童真魅力。使用正面直视的相机角度，搭配柔和的漫射光线，营造出温暖诱人的光泽。保持背景纯白色，以呈现干净现代的外观。色彩搭配应鲜明而舒缓，增强玩具般的吸引力。风格：超精细、奇幻、超可爱，将现实主义与柔软的毛绒质感相结合，以达到最大的视觉冲击力。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "emoji",
+        "fantasy",
+        "toy"
+      ],
+      "coverImage": "images/203.jpeg"
+    },
+    {
+      "id": 202,
+      "slug": "prompt-202",
+      "title": "创建半透明图标",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1942945882548437243"
+      },
+      "images": [
+        "images/202.jpeg",
+        "images/202-2.jpeg"
+      ],
+      "prompts": [
+        "Create a 3D-rendered icon of [Subject] in a dreamy, translucent, glass-like plastic material with soft pink and purple hues. glossy, smooth, rounded edges, glowing highlights, and soft shimmer or sparkle effects. UI, floating against a clean white background with soft shadows and natural lighting, elegant, and modern.",
+        "创建一个以[主题]为原型的 3D 渲染图标，采用梦幻般的、半透明的、类似玻璃的塑料材质，带有柔和的粉红色和紫色色调。表面光亮、边缘圆润、高光闪烁，并带有柔和的闪烁或闪光效果。UI 设计，悬浮在干净的白色背景上，带有柔和的阴影和自然光照，优雅且现代。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "nature",
+        "ui"
+      ],
+      "coverImage": "images/202.jpeg"
+    },
+    {
+      "id": 201,
+      "slug": "prompt-201",
+      "title": "纸上的小卡通角色",
+      "source": {
+        "name": "@jimmj1010",
+        "url": "https://x.com/jimmj1010/status/1943040595213324313"
+      },
+      "images": [
+        "images/201.jpeg",
+        "images/201-2.jpeg"
+      ],
+      "prompts": [
+        "Imagine you’re a tiny cartoon character who has come to life on a piece of paper! Draw yourself running away from a giant pencil that’s trying to erase you. Add colorful pencils, a desk, and maybe some flying eraser bits for extra excitement. Use your wildest imagination to make it look like you’re bursting out of the page!",
+        "想象你是一个在纸上活过来的小卡通角色！画自己从一只试图擦掉你的巨大铅笔逃跑。添加彩色铅笔、书桌，也许还有一些飞行的橡皮屑以增加乐趣。用你最狂野的想象力让它看起来像是从页面上爆发出来！"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "README.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "paper-craft",
+        "vehicle"
+      ],
+      "coverImage": "images/201.jpeg"
+    },
+    {
+      "id": 200,
+      "slug": "prompt-200",
+      "title": "真人和风格对照直出",
+      "source": {
+        "name": "@ZHO_ZHO_ZHO",
+        "url": "https://x.com/ZHO_ZHO_ZHO/status/1935620536090153216"
+      },
+      "images": [
+        "images/200.jpeg"
+      ],
+      "prompts": [
+        "创建图片 {\n\"title\": \"真人 × 动画对照创意作品\",\n\"author\": \"ZH4O\",\n\"description\": \"一张利用垂直拼贴与留白，将同一人物的照片与插画并置的创意作品，突出媒介在语言、质感与情绪上的对比。\",\n\"layout\": {\n\"orientation\": \"vertical\",\n\"photo\": {\n\"position\": \"top-left\",\n\"aspect_ratio\": \"3:4\",\n\"style\": \"street photo\",\n\"camera_angle\": \"eye-level, slightly tilted left\",\n\"lens\": \"mild wide-angle\",\n\"background_elements\": [\"road\", \"store signs\", \"urban perspective lines\"]\n},\n\"illustration\": {\n\"position\": \"bottom-right\",\n\"scale\": \"slightly larger\",\n\"composition\": \"2/3 body, medium shot\",\n\"pose\": \"similar to photo\",\n\"motion_direction\": \"curve extending top-right\",\n\"balance\": \"forms visual counterpoint to photo\"\n},\n\"background\": {\n\"color\": \"pure white\",\n\"purpose\": \"breathing space, minimalism, focus\"\n}\n},\n\"color_and_lighting\": {\n\"photo\": {\n\"dominant_tones\": \"neutral warm gray\",\n\"light_source\": \"natural light\",\n\"highlight_effects\": \"soft overexposure, summer glare\",\n\"key_elements\": [\"white dress with gauzy texture\", \"cement, scooter, wall as low-saturation backdrop\"]\n},\n\"illustration\": {\n\"style\": \"cartoon, simplified color blocks\",\n\"skin\": \"warm orange with soft pink blush\",\n\"hair\": \"deep brown, almost flat color\",\n\"dress\": \"white with minimal shading to indicate folds\",\n\"contrast\": \"high, compressed tonal range\",\n\"focus\": \"sharp character silhouette\"\n},\n\"background\": {\n\"function\": \"isolates media contrast, emphasizes character and action\"\n}\n},\n\"style_comparison_and_details\": {\n\"photo\": {\n\"gesture\": \"hand shading forehead\",\n\"expression\": \"wide eyes, slightly pouting lips, playful with a hint of exasperation\",\n\"context\": \"spontaneous, tight alley space, loose hair movement\"\n},\n\"illustration\": {\n\"design_inspiration\": \"Disney/CalArts style\",\n\"features\": [\"large eyes\", \"wide cheekbones\", \"pointy chin\", \"freckles\", \"blush\"],\n\"motion_effects\": \"exaggerated hair and skirt movement\",\n\"line_quality\": \"fluid and bouncy\",\n\"reproduction\": \"pose, expression, dress bow, forehead hair accurately translated\"\n}\n},\n\"visual_and_communication_value\": {\n\"themes\": [\"reality to animation transformation\", \"character design\", \"personified self-portrait\"],\n\"usability\": [\"IP development\", \"illustration demo\", \"fashion branding\"],\n\"design_elements\": [\"space for text/logo\", \"poster/social media-ready\"],\n\"narrative_strength\": \"uses white space as frame, pose as link, and medium contrast as core interest\",\n\"tone\": \"light, stylish, socially shareable\"\n}\n}",
+        "创建图片 {\n“title”： “真人 × 动画对照创意作品”，\n“author”： “ZH4O”， ZH4O“， ZH4O\n“description”： “一张利用垂直拼贴与留白，将同一人物的照片与插画并置的创意作品，突出媒介在语言、质感与情绪上的对比。\",\n“布局”： {\n“orientation”： “垂直”，\n“照片”： {\n“position”： “左上角”，\n“aspect_ratio”： “3：4”，\n“style”： “街拍”，\n“camera_angle”： “与眼睛齐平，略微向左倾斜”，\n“lens”： “轻度广角”，\n“background_elements”： [“road”， “shop signs”， “urban perspective lines”]\n},\n“插图”： {\n“position”： “右下角”，\n“scale”： “稍大”，\n“composition”： “2/3 体，中镜头”，\n“pose”： “与照片相似”，\n“motion_direction”： “曲线向右延伸”，\n“balance”： “形成与照片的视觉对位”\n},\n“背景”： {\n“color”： “纯白色”，\n“purpose”： “呼吸空间、极简主义、专注”\n}\n},\n“color_and_lighting”： {\n“照片”： {\n“dominant_tones”： “中性暖灰色”，\n“light_source”： “自然光”，\n“highlight_effects”： “柔和的过度曝光，夏季眩光”，\n“key_elements”： [“带有薄纱纹理的白色连衣裙”， “水泥、滑板车、墙壁作为低饱和度背景”]\n},\n“插图”： {\n“style”： “卡通，简化的色块”，\n“skin”： “暖橙色带柔和的粉红色腮红”，\n“hair”： “深棕色，几乎是单色”，\n“dress”： “白色，带有最小阴影以表示褶皱”，\n“contrast”： “高、压缩的色调范围”，\n“focus”： “清晰的角色剪影”\n},\n“背景”： {\n“function”： “隔离媒体对比度，强调角色和动作”\n}\n},\n“style_comparison_and_details”： {\n“照片”： {\n“gesture”： “手部阴影额头”，\n“expression”： “睁大眼睛，微微撅起嘴唇，俏皮中带着一丝恼怒”，\n“context”： “自发、狭窄的小巷空间、松散的头发移动”\n},\n“插图”： {\n“design_inspiration”： “Disney/CalArts 风格”，\n“features”： [“大眼睛”， “宽颧骨”， “尖下巴”， “雀斑”， “腮红”]，\n“motion_effects”： “夸张的头发和裙子运动”，\n“line_quality”： “流体和弹性”，\n“reproduction”： “姿势、表情、裙子蝴蝶结、额头头发准确翻译”\n}\n},\n“visual_and_communication_value”： {\n“themes”： [“从现实到动画的转变”， “角色设计”， “拟人化自画像”]，\n“可用性”： [“IP 开发”， “插图演示”， “时尚品牌”]，\n“design_elements”： [“文本/徽标空间”， “海报/社交媒体就绪”]，\n“narrative_strength”： “使用空白作为框架，使用姿势作为链接，使用中等对比度作为核心兴趣”，\n“tone”： “轻盈、时尚、社交分享”\n}\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "cartoon",
+        "character",
+        "fashion",
+        "illustration",
+        "minimalist",
+        "nature",
+        "photography",
+        "portrait",
+        "poster",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/200.jpeg"
+    },
+    {
+      "id": 199,
+      "slug": "prompt-199",
+      "title": "自定义纹理的复古玩具",
+      "source": {
+        "name": "@_abranko_",
+        "url": "https://x.com/_abranko_/status/1938936595257688552"
+      },
+      "images": [
+        "images/199.png",
+        "images/199-2.jpeg"
+      ],
+      "prompts": [
+        "Retexture the uploaded image based on the JSON\n\n{\n  \"materials\": {\n    \"exterior\": \"matte injection-molded plastic\",\n    \"interior\": [\n      \"blocky colored plastic parts\",\n      \"oversized gears\",\n      \"simple rods\",\n      \"basic springs\",\n      \"toy decals\"\n    ]\n  },\n  \"lighting\": {\n    \"type\": \"studio soft light\",\n    \"direction\": \"top and front fill\",\n    \"color\": \"warm daylight\",\n    \"mood\": \"nostalgic, cheerful\"\n  },\n  \"background\": {\n    \"type\": \"solid\",\n    \"color\": \"pastel yellow\"\n  },\n  \"camera\": {\n    \"angle\": \"eye-level side\",\n    \"focus\": \"medium sharp\",\n    \"depth_of_field\": \"deep\"\n  },\n  \"color_palette\": {\n    \"dominant\": [\"red\", \"blue\", \"yellow\"],\n    \"accents\": [\"mint green\", \"white\", \"peach\"]\n  },\n  \"vibe\": \"1980s retro toy, nostalgic, playful\"\n}",
+        "根据 JSON 对上传的图片进行重新纹理处理\n\n{\n“材料”： {\n“exterior”： “哑光注塑成型塑料”，\n“interior”：[\n“块状彩色塑料件”，\n“超大齿轮”，\n“简单杆”，\n“基本弹簧”，\n“玩具贴花”\n    ]\n  },\n“照明”： {\n“type”： “工作室柔光”，\n“direction”： “顶部和前部填充”，\n“color”： “暖日光”，\n“mood”： “怀旧的、欢快的”\n  },\n“背景”： {\n“type”： “solid”， //类型\n“color”： “柔和的黄色”\n  },\n“相机”： {\n“angle”： “与眼睛齐平的一侧”，\n“focus”： “中等锐化”，\n“depth_of_field”： “deep”\n  },\n“color_palette”： {\n“主导”： [“红”， “蓝”， “黄”]，\n“accents”： [“薄荷绿”， “白色”， “桃子”]\n  },\n“vibe”： “1980 年代复古玩具，怀旧，俏皮”\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "nature",
+        "retro",
+        "toy"
+      ],
+      "coverImage": "images/199.png"
+    },
+    {
+      "id": 198,
+      "slug": "prompt-198",
+      "title": "可爱的设计师玩偶",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1936423426006151467"
+      },
+      "images": [
+        "images/198.png",
+        "images/198-2.jpeg"
+      ],
+      "prompts": [
+        "A cute designer doll styled as a [SUBJECT]. The doll has a porcelain face with blush, soft curly white hair, and large expressive eyes with unique pupils (like a star and moon). It wears a fluffy pastel-colored costume resembling the [chosen creature or idea], with detailed accessories like a hood with ears or horns, lace, and a ribbon. Embroidery on the paws reflects the character’s theme. The doll is sitting on a neutral background (like beige leather or soft fabric). The atmosphere is dreamy and whimsical, with soft lighting. Style: Korean collectible art doll, highly detailed, pastel color palette.",
+        "一个可爱的设计师玩偶，造型为 [SUBJECT]。娃娃有一张瓷脸，脸上泛着腮红，柔软的卷曲白发，还有一双富有表现力的大眼睛和独特的瞳孔（像星星和月亮）。它穿着一件蓬松的柔和色服装，类似于 [选择的生物或想法]，带有详细的配饰，如带耳朵或角的兜帽、蕾丝和丝带。爪子上的刺绣反映了角色的主题。娃娃坐在中性背景上（如米色皮革或柔软的织物）。气氛梦幻而异想天开，灯光柔和。风格：韩国收藏艺术娃娃，高度详细，柔和的调色板。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "character",
+        "fashion"
+      ],
+      "coverImage": "images/198.png"
+    },
+    {
+      "id": 197,
+      "slug": "prompt-197",
+      "title": "数字粘土雕塑",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1936378648891936803"
+      },
+      "images": [
+        "images/197.png",
+        "images/197-2.jpeg"
+      ],
+      "prompts": [
+        "A digital clay sculpture of a [subject], captured in a [pose/action], resting on a minimalist [color] plinth etched with organic swirl patterns. The sculpt features smooth, flowing curves and a tactile finish, rendered in a refined [color palette] that evokes a soft, contemporary aesthetic.",
+        "一个 [主题] 的数字粘土雕塑，以 [姿势/动作] 捕捉，放在极简主义的 [彩色] 基座上，上面蚀刻有有机漩涡图案。雕塑具有流畅、流畅的曲线和触感，以精致的 [调色板] 呈现，唤起柔和的现代美学。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "clay",
+        "minimalist",
+        "sculpture"
+      ],
+      "coverImage": "images/197.png"
+    },
+    {
+      "id": 196,
+      "slug": "prompt-196",
+      "title": "字母景观",
+      "source": {
+        "name": "@BeanieBlossom",
+        "url": "https://x.com/BeanieBlossom/status/1936333318540456354"
+      },
+      "images": [
+        "images/196.jpeg",
+        "images/196-2.jpeg"
+      ],
+      "prompts": [
+        "the letter B beautiful and elegant decorated with a beautiful beachscape",
+        "字母 B 美丽典雅，装饰美丽的海滩景观"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "landscape"
+      ],
+      "coverImage": "images/196.jpeg"
+    },
+    {
+      "id": 195,
+      "slug": "prompt-195",
+      "title": "经典的微型玩具风格",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1936480873378955432"
+      },
+      "images": [
+        "images/195.png",
+        "images/195-2.jpeg"
+      ],
+      "prompts": [
+        "A miniature version of [LOCATION], designed in a whimsical dollhouse style. The structure is surrounded by thematic natural elements and tiny architectural details that reflect its cultural context (e.g., plants, paths, decor). The color palette uses soft pastels (such as coral, blush, sand, mint, or dusty green), with warm cinematic lighting and a serene, dreamy atmosphere. Highly detailed, cozy and stylized. Isometric view, vertical 9:16 format, on a clean studio background.",
+        "[LOCATION] 的微型版本，以异想天开的玩具屋风格设计。该结构周围环绕着主题自然元素和反映其文化背景的微小建筑细节（例如，植物、小径、装饰）。调色板使用柔和的粉彩（如珊瑚色、腮红色、沙色、薄荷色或灰绿色），具有温暖的电影照明和宁静、梦幻的氛围。高度详细、舒适且风格化。等距视图，垂直 9：16 格式，位于干净的工作室背景上。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "nature",
+        "toy"
+      ],
+      "coverImage": "images/195.png"
+    },
+    {
+      "id": 194,
+      "slug": "prompt-194",
+      "title": "装饰艺术未来主义",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1936095679879037143"
+      },
+      "images": [
+        "images/194.jpeg"
+      ],
+      "prompts": [
+        "create image with 1:1 ratio \n[Brand] ad. Ultra-high-detail product photo in a fusion of Art Deco and Futurism. The product rest on platforms.  Background features stylized Art Deco skyscraper silhouettes morphing into Futurist speed lines, forming a diagonal left-to-right composition. Surfaces use brand Core Material and faceted glass with ambient lighting in Brand Color theme.  The product evoking motion and kinetic optimism. Dramatic low-angle lighting enhances reflections, with subtle vapor trails in the background.  Small logo on the bottom, and a tiny slogan beneath",
+        "以 1：1 的比例创建图像\n[品牌] 广告。融合了装饰艺术和未来主义的超高细节产品照片。该产品位于平台上。 背景以风格化的装饰艺术摩天大楼剪影转变为未来主义的速度线条，形成从左到右的对角线构图。表面使用品牌核心材料和多面玻璃，并在品牌颜色主题中使用环境照明。 该产品唤起了动感和动感的乐观主义。戏剧性的低角度照明增强了反射，背景中带有微妙的蒸汽痕迹。 底部有小标志，下面有一个小标语"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "futuristic",
+        "logo",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/194.jpeg"
+    },
+    {
+      "id": 193,
+      "slug": "prompt-193",
+      "title": "将您的徽标放在月球上",
+      "source": {
+        "name": "@alex_prompter",
+        "url": "https://x.com/alex_prompter/status/1935739243352989945"
+      },
+      "images": [
+        "images/193.jpeg"
+      ],
+      "prompts": [
+        "Recreate [BRAND NAME] logo following my JSON aesthetic below:\n{\n\"role\": \"You are a lunar scene generator trained on NASA’s Apollo archives. Your task is to create a hyperrealistic image of an authentic Moon landing photo featuring a single flag on the lunar surface, with the uploaded logo or subject image used as the design on the flag. Maintain all original colors, shapes, and text. Do not alter or reinterpret the uploaded image. No substitutions allowed.\",\n\"instructions\": {\n\"integration_mode\": \"printed flag only\",\n\"uploaded_image_used_as_flag_art\": true,\n\"preserve_logo_shape_and_text_layout\": true,\n\"preserve_original_colors_exactly\": true,\n\"do_not_redesign_or_substitute\": true,\n\"flag_behavior\": {\n\"material\": \"textured woven fabric\",\n\"look\": \"NASA-style rectangular flag\",\n\"motion\": \"slightly waving with natural wrinkles, due to support bar\"\n},\n\"flag_pole_structure\": {\n\"number_of_poles\": 1,\n\"position\": \"single vertical metal pole on the left edge of the flag\",\n\"material\": \"silver aluminum, as used in Apollo 11 mission\",\n\"support_bar\": \"horizontal crossbar at top to keep fabric extended\",\n\"avoid_layouts\": [\n\"dual flagpoles\",\n\"mirrored mounts\",\n\"hanging banners\",\n\"floating flag with no pole\"\n]\n}\n},\n\"scene_details\": {\n\"location\": \"Moon surface near landing module\",\n\"lighting\": \"sharp sunlight casting long shadows from top left\",\n\"terrain\": \"gray lunar dust with bootprints, small craters, regolith texture\",\n\"background\": \"black sky with no stars, horizon line visible\",\n\"camera_angle\": \"low-angle shot, 3/4 profile of flag\",\n\"optional_elements\": {\n\"astronaut\": \"in classic white suit saluting or standing beside flag\",\n\"timestamp_text\": \"JUL 20, 1969\",\n\"NASA_patch\": \"optional small logo in corner of photo frame\"\n}\n},\n\"visual_style\": {\n\"photo_treatment\": \"Apollo-style film realism\",\n\"resolution\": \"high fidelity — minimum 1600x1200\",\n\"color_mode\": \"realistic photo with accurate flag color preserved\",\n\"film_effects\": {\n\"subtle_grain\": true,\n\"analog_color_balance\": true,\n\"mild_lens_flare\": \"optional from top left sun\"\n}\n},\n\"image_constraints\": {\n\"aspect_ratio\": \"4:3\",\n\"transparent_background\": false,\n\"full_scene_required\": true,\n\"no_crop_on_flag_or_pole\": true,\n\"subject_centered\": \"flag is central focus of composition\"\n},\n\"notes\": \"Do not generate stylized interpretations. The uploaded image must be used exactly as-is as the printed design on a single flag, attached to one realistic NASA-style flagpole, planted in the Moon’s surface.\"\n}",
+        "按照下面的 JSON 美学重新创建 [BRAND NAME] 徽标：\n{\n“role”： “您是在 NASA 的 Apollo 档案中训练的月球场景生成器。您的任务是创建一张真实的登月照片的超写实图像，其中月球表面有一面旗帜，并将上传的徽标或主题图像用作旗帜上的设计。保留所有原始颜色、形状和文本。请勿更改或重新解释上传的图像。不允许替换。\n“instructions”： {\n“integration_mode”： “仅打印旗帜”，\n“uploaded_image_used_as_flag_art”： true，\n“preserve_logo_shape_and_text_layout”：true、\n“preserve_original_colors_exactly”：true、\n“do_not_redesign_or_substitute”： true，\n“flag_behavior”： {\n“material”： “纹理编织布”，\n“look”： “NASA 风格的矩形旗帜”，\n“motion”： “由于支撑杆的原因，轻微波动并带有自然皱纹”\n},\n“flag_pole_structure”：{\n“number_of_poles”：1、\n“position”： “旗帜左边缘的单个垂直金属杆”，\n“material”： “阿波罗 11 号任务中使用的银铝”，\n“support_bar”： “顶部水平横杆，以保持织物伸展”，\n“avoid_layouts”：[\n“双旗杆”，\n“镜像挂载”，\n“悬挂横幅”，\n“无杆浮动旗”\n]\n}\n},\n“scene_details”： {\n“location”： “着陆舱附近的月球表面”，\n“lighting”： “从左上角投下长长的阴影的强烈阳光”，\n“terrain”： “灰色月尘，有靴印、小陨石坑、风化层纹理”，\n“background”： “没有星星的黑色天空，可见地平线”，\n“camera_angle”： “低角度拍摄，旗帜的 3/4 轮廓”，\n“optional_elements”： {\n“astronaut”： “身穿经典白色西装敬礼或站在国旗旁”，\n“timestamp_text”： “1969 年 7 月 20 日”，\n“NASA_patch”： “相框一角可选小标志”\n}\n},\n“visual_style”： {\n“photo_treatment”： “阿波罗式电影现实主义”，\n“resolution”： “高保真 — 最低 1600x1200”，\n“color_mode”： “保留准确国旗颜色的逼真照片”，\n“film_effects”： {\n“subtle_grain”：true、\n“analog_color_balance”：true、\n“mild_lens_flare”： “从左上角太阳可选”\n}\n},\n“image_constraints”： {\n“aspect_ratio”： “4：3”，\n“transparent_background”： false，\n“full_scene_required”： true，\n“no_crop_on_flag_or_pole”： true，\n“subject_centered”： “旗帜是构图的中心焦点”\n},\n“notes”： “不要生成程式化的解释。上传的图像必须与单面旗帜上的印刷设计完全一样使用，该旗帜连接到一根安装在月球表面的逼真的 NASA 风格旗杆上。\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "logo",
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/193.jpeg"
+    },
+    {
+      "id": 192,
+      "slug": "prompt-192",
+      "title": "月光屋顶茶话会",
+      "source": {
+        "name": "@BeanieBlossom",
+        "url": "https://x.com/BeanieBlossom/status/1935608566406344905"
+      },
+      "images": [
+        "images/192.jpeg",
+        "images/192-2.jpeg"
+      ],
+      "prompts": [
+        "A moonlight rooftop tea party between a girl and a boy, dreamy, gentle, painterly.",
+        "一个女孩和一个男孩的月光屋顶茶话会，梦幻、温柔、绘画。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/192.jpeg"
+    },
+    {
+      "id": 191,
+      "slug": "prompt-191",
+      "title": "后世界末日氛围",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1935369568408523045"
+      },
+      "images": [
+        "images/191.jpeg",
+        "images/191-2.jpeg"
+      ],
+      "prompts": [
+        "a young cartoon boy with big goggles and scarf driving a tiny makeshift vehicle in the desert, cute post-apocalyptic vibe, indie animation style, soft colors, emotional and adventurous --ar 3:4 --raw --p",
+        "一个戴着大护目镜和围巾的年轻卡通男孩在沙漠中驾驶着一辆小型临时车辆，可爱的后世界末日氛围，独立动画风格，柔和的色彩，情感和冒险 --AR 3：4 --原始 --p"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "vehicle"
+      ],
+      "coverImage": "images/191.jpeg"
+    },
+    {
+      "id": 190,
+      "slug": "prompt-190",
+      "title": "品牌虚拟人物",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1939218188513726675"
+      },
+      "images": [
+        "images/190.png",
+        "images/190-2.png"
+      ],
+      "prompts": [
+        "A fictional character shaped like a [Brand Name] product, wearing clothing that reflects the brand’s identity, sitting or riding on an oversized version of one of the brand's products as if it were a futuristic vehicle. The design features an expressive, dynamic artistic style full of motion and vibrant colors, with a large abstract version of the brand’s logo in the background. Freely drawn elements and colors representing the brand are scattered throughout. The background is light-colored, and the brand’s logo appears at the bottom. aspect 1:1",
+        "一个形状像 [品牌名称] 商品的虚构人物，穿着反映品牌身份的服装，坐在或骑在该品牌某件商品的超大版本上，就好像它是一辆未来主义的汽车一样。该设计具有富有表现力、充满活力的艺术风格，充满动感和鲜艳的色彩，背景是品牌标志的大型抽象版本。代表品牌的自由绘制元素和颜色散布在整个过程中。背景为浅色，品牌标志出现在底部。外观 1：1"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "character",
+        "fashion",
+        "futuristic",
+        "logo",
+        "portrait",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/190.png"
+    },
+    {
+      "id": 189,
+      "slug": "prompt-189",
+      "title": "心爱的角色制作动漫风格的签名",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1938601703026434134"
+      },
+      "images": [
+        "images/189.png",
+        "images/189-2.jpeg"
+      ],
+      "prompts": [
+        "A minimalistic black-and-white autograph design in a single-line drawing style, featuring the handwritten signature: [CHARACTER NAME], integrated with cute line art elements inspired by the character’s appearance and personality (for example: hair, outfit details, weapons, magical symbols). Include a small mascot or doodle of the character in simplified chibi style, surrounded by decorative elements (stars, hearts, sparkles, musical notes, flowers) that match their vibe. Clean, cute, modern design suitable for tattoo or sticker. High-resolution line art.",
+        "简约的黑白亲笔签名设计，采用单线绘图风格，带有手写签名：[CHARACTER NAME]，并融入了受角色外表和个性启发的可爱线条艺术元素（例如：头发、服装细节、武器、魔法符号）。包括一个简化的赤壁风格的小吉祥物或角色涂鸦，周围环绕着与其氛围相匹配的装饰元素（星星、心形、火花、音符、花朵）。干净、可爱、现代的设计，适合纹身或贴纸。高分辨率线条图。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fashion",
+        "minimalist",
+        "nature",
+        "paper-craft"
+      ],
+      "coverImage": "images/189.png"
+    },
+    {
+      "id": 188,
+      "slug": "prompt-188",
+      "title": "微型毛毡羊毛人物",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1939277984441250111"
+      },
+      "images": [
+        "images/188.png",
+        "images/188-2.png"
+      ],
+      "prompts": [
+        "A felted wool figure of a [subject], handcrafted with soft fibers, uneven stitching, and visible textures. Set within a miniature diorama of layered fabrics and pastel props, the scene radiates cozy, storybook charm like a still from a tactile, stop-motion fairytale made entirely of felt and thread.",
+        "一个 [主题] 的毛毡羊毛人物，用柔软的纤维手工制作，缝线不均匀，纹理可见。该场景设置在分层织物和柔和道具的微型立体模型中，散发着舒适的故事书魅力，就像完全由毛毡和线制成的触觉定格动画童话中的剧照。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "felt",
+        "landscape",
+        "portrait"
+      ],
+      "coverImage": "images/188.png"
+    },
+    {
+      "id": 187,
+      "slug": "prompt-187",
+      "title": "新卡通风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1939248601252651046"
+      },
+      "images": [
+        "images/187.png"
+      ],
+      "prompts": [
+        "Transform this image into a classic Tex Avery / Looney Tunes cartoon style. Use bold, clean outlines and exaggerated character features — huge eyes, stretched limbs, and over-the-top facial expressions. Emphasize slapstick comedy and visual humor. Colors should be vibrant and flat, with high contrast. Backgrounds should be simple, painted with soft gradients or flat colors, keeping focus on the character's action. Add motion lines, expressive effects (like sweat drops, stars, impact bursts), and a dynamic pose typical of 1940s Warner Bros. animation. The final result should look like a freeze frame from a mid-century animated short — full of cartoon energy and absurd charm.",
+        "将此图像转换为经典的 Tex Avery / Looney Tunes 卡通风格。使用大胆、干净的轮廓和夸张的角色特征 - 大眼睛、伸展的四肢和夸张的面部表情。强调滑稽喜剧和视觉幽默。颜色应鲜艳、平坦，具有高对比度。背景应该简单，用柔和的渐变或单调的颜色绘制，保持对角色动作的关注。添加运动线条、富有表现力的效果（如汗珠、星星、冲击爆发）和 1940 年代华纳兄弟动画的典型动态姿势。最终结果应该看起来像上世纪中叶动画短片的定格——充满卡通能量和荒诞的魅力。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "vehicle"
+      ],
+      "coverImage": "images/187.png"
+    },
+    {
+      "id": 186,
+      "slug": "prompt-186",
+      "title": "装饰艺术大都会",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1939054964405305830"
+      },
+      "images": [
+        "images/186.png",
+        "images/186-2.png"
+      ],
+      "prompts": [
+        "[SUBJECT] set within an Art Deco Metropolis, showcasing the grandeur and geometric elegance of 1920s architecture. Use streamlined forms and ornamental details, highlighting a sophisticated color palette of [COLOR1] and [COLOR2] to reflect the prosperity of the era.",
+        "[主题] 位于装饰艺术大都市内，展示了 1920 年代建筑的宏伟和几何优雅。使用流线型的形式和装饰性细节，突出 [COLOR1] 和 [COLOR2] 的复杂调色板，以反映那个时代的繁荣。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "architecture"
+      ],
+      "coverImage": "images/186.png"
+    },
+    {
+      "id": 185,
+      "slug": "prompt-185",
+      "title": "人体工程学",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1938969169296228706"
+      },
+      "images": [
+        "images/185.png",
+        "images/185-2.jpeg"
+      ],
+      "prompts": [
+        "Imagine a [piece of furniture] designed in the form of [creature/object/concept]. The design should be highly creative and sculptural, like an art piece. Use organic, flowing shapes and detailed textures. Make sure it remains functional and ergonomic. The goal is for it to be both visually striking and practical —something you’d expect to see as a museum-quality design object",
+        "想象一下以 [生物/物体/概念] 的形式设计的 [家具]。设计应该具有高度的创意和雕塑感，就像一件艺术品。使用有机、流畅的形状和详细的纹理。确保它保持功能正常且符合人体工程学。目标是让它既具有视觉冲击力又具有实用性——您希望看到的是博物馆品质的设计对象"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "sculpture"
+      ],
+      "coverImage": "images/185.png"
+    },
+    {
+      "id": 184,
+      "slug": "prompt-184",
+      "title": "乐高风格套装",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1939271090678779980"
+      },
+      "images": [
+        "images/184.png",
+        "images/184-2.jpeg"
+      ],
+      "prompts": [
+        "a realistic LEGO-style set featuring [COUNTRY]’s national treasure: [ITEM]. Photorealistic packaging with LEGO branding, box art showing the built model, the model assembled from LEGO bricks in authentic colors and details. Studio product photography with soft shadows and clear lighting, highly detailed, professional commercial render. Include box and bricks in the scene, focus on realism and LEGO-like style. 9:16.",
+        "以 [COUNTRY] 的国宝 [ITEM] 为特色的逼真乐高风格套装。带有乐高品牌的逼真包装，展示拼搭模型的盒子艺术，模型由乐高积木组装而成，具有逼真的颜色和细节。具有柔和阴影和清晰照明的工作室产品摄影，高度详细的专业商业渲染。在场景中加入盒子和积木，注重真实感和类似乐高的风格。9:16."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/184.png"
+    },
+    {
+      "id": 183,
+      "slug": "prompt-183",
+      "title": "霓虹效果海报",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1939059047149289595"
+      },
+      "images": [
+        "images/183.jpeg",
+        "images/183-2.png"
+      ],
+      "prompts": [
+        "a single [OBJECT] glowing vividly with internal neon light that matches its brand or essence — the glow must follow the object’s shape and details precisely without overexposing — cinematic studio lighting — rich reflective surface or texture — subtle ambient fog or mist around the object — sharp shadows and clean contrast — floating or standing on a soft reflective black surface — ultra-sharp details — 2:3 vertical layout — pure black background — high-Kelvin lighting to avoid yellow tint — ultra-HD photorealism — the glow must feel premium, dramatic, and emotionally pow",
+        "单个 [对象] 用与其品牌或本质相匹配的内部霓虹灯发出生动的光芒 — 光芒必须精确地跟随对象的形状和细节，而不会过度曝光 — 电影摄影棚照明 — 丰富的反射表面或纹理 — 对象周围微妙的环境雾或薄雾 — 清晰的阴影和清晰的对比度 — 漂浮或站在柔和的反光黑色表面上 — 超清晰的细节 — 2：3 垂直布局 — 纯黑色背景 — 高开尔文照明以避免黄色调 — 超高清照片级真实感 — 发光必须让人感觉优质、戏剧性且情感上充满情感冲击"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "neon",
+        "photography",
+        "poster"
+      ],
+      "coverImage": "images/183.jpeg"
+    },
+    {
+      "id": 182,
+      "slug": "prompt-182",
+      "title": "鸟类羽毛制成LOGO",
+      "source": {
+        "name": "@Gdgtify",
+        "url": "https://x.com/Gdgtify/status/1938901186616471840"
+      },
+      "images": [
+        "images/182.jpeg"
+      ],
+      "prompts": [
+        "A detailed overhead shot of a fluid, colorful OpenAI logo created by arranging hundreds of naturally shed exotic bird feathers. Capture the incredible iridescence, delicate barbs, and varied textures against a misty white backdrop with side lighting.",
+        "流畅、多彩的 OpenAI 徽标的详细俯拍镜头，由数百根自然脱落的异国鸟类羽毛制成。在带有侧面照明的朦胧白色背景下捕捉令人难以置信的彩虹色、精致的倒钩和各种纹理。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "logo",
+        "nature"
+      ],
+      "coverImage": "images/182.jpeg"
+    },
+    {
+      "id": 181,
+      "slug": "prompt-181",
+      "title": "抽象液体排版文字",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1938599250738503861"
+      },
+      "images": [
+        "images/181.jpeg",
+        "images/181-2.jpeg"
+      ],
+      "prompts": [
+        "Abstract liquid typography spelling \"text\", made of thick, transparent water-gel with realistic refraction and soft shadows. Each letter appears sculpted from droplets with surface tension, smooth curves, and light reflections. Water droplets scattered on the surface, minimal background, hyper-realistic lighting, photorealistic render",
+        "抽象液体排版拼写“text”，由厚实、透明的水凝胶制成，具有逼真的折射和柔和的阴影。每个字母都由具有表面张力、平滑曲线和光反射的水滴雕刻而成。散落在表面上的水滴、极小的背景、超逼真的照明、照片级逼真的渲染"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "minimalist",
+        "photography",
+        "typography"
+      ],
+      "coverImage": "images/181.jpeg"
+    },
+    {
+      "id": 180,
+      "slug": "prompt-180",
+      "title": "可爱粉彩乙烯基人物",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1938688543284707403"
+      },
+      "images": [
+        "images/180.png",
+        "images/180-2.png",
+        "images/180-3.png"
+      ],
+      "prompts": [
+        "A cute pastel vinyl figure of [INSERT YOUR CHARACTER OR OBJECT], pastel colors (lavender, soft pink, baby blue), kawaii style with big round eyes and friendly smile, simple rounded shapes, stylized “RIP” detail somewhere on the figure or base, matching toy packaging in the background with themed art, studio product photo with soft lighting, minimal shadows",
+        "一个可爱的粉彩乙烯基人物 [插入您的角色或对象]，柔和的颜色（薰衣草色、柔和的粉红色、婴儿蓝色）、卡哇伊风格、圆圆的大眼睛和友好的微笑、简单的圆形形状、人物或底座上某处的程式化“RIP”细节、背景中的玩具包装与主题艺术相匹配、具有柔和灯光的工作室产品照片，最小的阴影"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "character",
+        "minimalist",
+        "photography",
+        "portrait",
+        "product",
+        "toy"
+      ],
+      "coverImage": "images/180.png"
+    },
+    {
+      "id": 179,
+      "slug": "prompt-179",
+      "title": "创建多种3D风格头像",
+      "source": {
+        "name": "@tranmautritam",
+        "url": "https://x.com/tranmautritam/status/1938160355064353153"
+      },
+      "images": [
+        "images/179.png",
+        "images/179-2.jpeg",
+        "images/179-3.jpeg"
+      ],
+      "prompts": [
+        "Create a 3D-rendered digital illustration of a stylized cartoon boy character, standing in a neutral pose. The character should be rendered in a realistic-minimalist 3D style, with soft rounded proportions and plush matte textures — similar to high-end Cinema 4D + Redshift product renders.",
+        "创建风格化卡通男孩角色的 3D 渲染数字插图，以中性姿势站立。角色应以逼真的极简主义 3D 风格渲染，具有柔和圆润的比例和毛绒哑光纹理——类似于高端 Cinema 4D + Redshift 产品渲染。",
+        "He has a warm natural skin tone with rosy cheeks, dot eyes (or small glossy eyes), and soft curly dark brown hair. Facial expression is neutral or slightly curious. Outfit includes an olive green T-shirt with rolled sleeves, beige rolled shorts, and off-white matte sneakers with subtle stitching. He wears a dark olive crossbody satchel with a flap, and a slim black watch on his right wrist.",
+        "他有着温暖自然的肤色，红润的脸颊，圆点的眼睛（或有光泽的小眼睛）和柔软的深棕色卷发。面部表情中性或略带好奇。服装包括一件卷袖的橄榄绿色 T 恤、米色卷短裤和带有微妙缝线的米白色哑光运动鞋。他戴着一个带翻盖的深橄榄色斜挎包，右手腕上戴着一块纤细的黑色手表。",
+        "Render with soft, diffused lighting and gentle shadows underfoot. Use a 100% transparent background (PNG format) or very light neutral grey if previewed. Full-body composition, front-facing or light 3/4 view. Maintain a clean, high-resolution, polished render — ideal for a character design showcase or branding. Soft color palette with earth tones.",
+        "使用柔和的漫射照明和脚下柔和的阴影进行渲染。使用 100% 透明背景（PNG 格式）或非常浅的中性灰色（如果预览）。全身构图，正面或浅色 3/4 视图。保持干净、高分辨率、精美的渲染 — 非常适合角色设计展示或品牌推广。带有大地色调的柔和调色板。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "cartoon",
+        "character",
+        "fashion",
+        "illustration",
+        "minimalist",
+        "nature",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/179.png"
+    },
+    {
+      "id": 178,
+      "slug": "prompt-178",
+      "title": "生物发光",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1938692576720085242"
+      },
+      "images": [
+        "images/178.png",
+        "images/178-2.png",
+        "images/178-3.jpeg",
+        "images/178-4.jpeg"
+      ],
+      "prompts": [
+        "[SUBJECT] depicted as a Mythical Creature Luminescence, with glowing edges that accentuate the fantastical and legendary aspects. Utilize [COLOR1] and [COLOR2] to enhance the mythical and enchanting qualities.",
+        "[对象] 被描绘成一个神话生物的发光，发光的边缘突出了奇幻和传奇的一面。利用 [COLOR1] 和 [COLOR2] 来增强神话和迷人的品质。",
+        "White Tiger depicted as a Mythical Creature Luminescence, with glowing edges that accentuate the fantastical and legendary aspects. Utilize icy blue and silver to enhance the mythical and enchanting qualities --ar 3:2 --v 7.0",
+        "White Tiger 被描绘成神话生物的发光，发光的边缘突出了奇幻和传奇的一面。利用冰蓝色和银色来增强神话和迷人的品质 --ar 3：2 --v 7.0"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "fantasy"
+      ],
+      "coverImage": "images/178.png"
+    },
+    {
+      "id": 177,
+      "slug": "prompt-177",
+      "title": "2D单词海报设计",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1938818077451325444"
+      },
+      "images": [
+        "images/177.jpeg",
+        "images/177-2.jpeg"
+      ],
+      "prompts": [
+        "Create a surreal 2D poster design based on the word “[KEYWORD]” — the layout should be dominated by kinetic typography where the word is visually shaped or distorted to reflect its meaning — integrate a symbolic flat minimal illustration that reinforces the concept — the style must be inspired by risograph print: only 2 bold contrasting colors (no gradients) — include a poetic, short quote that resonates emotionally with the keyword — background must be clean and minimal — composition must be vertical, with strong visual impact and artistic balance — the overall tone should feel cinematic, surreal, and graphic — ultra-sharp, high-resolution, no clutter",
+        "根据“[KEYWORD]”一词创作超现实主义的 2D 海报设计——布局应以动态排版为主，其中单词在视觉上被塑造或扭曲以反映其含义——加入一个象征性的平面最小插图来强化概念——风格必须受到 risograph 印刷品的启发：只有 2 种大胆的对比色（无渐变）——包括诗意的、 与关键词产生情感共鸣的简短引述 — 背景必须干净且最小 — 构图必须是垂直的，具有强烈的视觉冲击力和艺术平衡 — 整体基调应该感觉像电影、超现实和图形 — 超清晰、高分辨率、无杂乱"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "minimalist",
+        "poster",
+        "typography"
+      ],
+      "coverImage": "images/177.jpeg"
+    },
+    {
+      "id": 176,
+      "slug": "prompt-176",
+      "title": "三维几何效果",
+      "source": {
+        "name": "@BeanieBlossom",
+        "url": "https://x.com/BeanieBlossom/status/1938568084207665488"
+      },
+      "images": [
+        "images/176.jpeg",
+        "images/176-2.jpeg",
+        "images/176-3.jpeg"
+      ],
+      "prompts": [
+        "A bison in the center of an array of colorful geometric shapes, surrounded by symbols representing different aspects like family and home. The artwork features warm colors in an oil painting style, with an Art Nouveau illustration showcasing ornate details and colorful patterns. The scene also includes a night sky and desert landscapes. The artwork should have a rich texture and a three-dimensional effect with intricate detailing.",
+        "一头野牛位于一系列彩色几何形状的中心，周围环绕着代表不同方面的符号，如家庭和家。这件艺术品以油画风格的暖色调为特色，新艺术运动插图展示了华丽的细节和丰富多彩的图案。该场景还包括夜空和沙漠景观。图稿应具有丰富的纹理和具有复杂细节的三维效果。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "illustration",
+        "landscape"
+      ],
+      "coverImage": "images/176.jpeg"
+    },
+    {
+      "id": 175,
+      "slug": "prompt-175",
+      "title": "半透明晶体效果",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1938565095191089556"
+      },
+      "images": [
+        "images/175.jpeg",
+        "images/175-2.jpeg"
+      ],
+      "prompts": [
+        "a [SUBJECT] rendered as a translucent crystalline form with beveled edges, subtly glowing from within. Surfaces catch and reflect ambient light, revealing faint iridescent hues across its contours in dark background",
+        "一个 [SUBJECT] 渲染为带有斜边的半透明晶体形式，从内部微妙地发光。表面捕捉并反射环境光，在黑暗背景下在其轮廓上显示微弱的彩虹色"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/175.jpeg"
+    },
+    {
+      "id": 174,
+      "slug": "prompt-174",
+      "title": "生成电影氛围图",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1938635953280549061"
+      },
+      "images": [
+        "images/174.png",
+        "images/174-2.png",
+        "images/174-3.jpeg"
+      ],
+      "prompts": [
+        "Cinematic still, A [ description of the character or action scene], with a [ background/environment], a dynamic angle, a [light effect or lighting condition], motion blur, high-resolution photography, a cinematic scene, cinematic lighting, and high contrast.",
+        "电影静止图像、具有 [ 背景/环境] 、动态角度、[光效或照明条件]、运动模糊、高分辨率摄影、电影场景、电影照明和高对比度。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "character",
+        "landscape",
+        "photography"
+      ],
+      "coverImage": "images/174.png"
+    },
+    {
+      "id": 173,
+      "slug": "prompt-173",
+      "title": "复古风格图标",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1938613929413869705"
+      },
+      "images": [
+        "images/173.jpeg",
+        "images/173-2.jpeg"
+      ],
+      "prompts": [
+        "Create an illustration of a [OBJECT] in a retro cartoon style. Use only flat, solid colors with no gradients, smudging, airbrushing, or blur. All shading and highlights should be made from clean, separate color blocks. Outline all shapes with thick, bold black lines. Use a simplified color palette (such as teal, coral, mustard, and white) for a vintage feel. Add small sparkle accents or motion lines for charm, but keep the icon the clear focus. Set the illustration on a plain white background. The final result must be crisp, clean, and vector friendly with sharp edges and no texture or raster effects. Square aspect ratio.",
+        "创建复古卡通风格的 [OBJECT] 插图。仅使用单色，不要使用渐变、涂抹、喷枪或模糊。所有阴影和高光都应由干净、独立的色块制成。用粗大的黑色线条勾勒出所有形状的轮廓。使用简化的调色板（如蓝绿色、珊瑚色、芥末色和白色）以获得复古感。添加小的闪光点缀或动感线条以增加魅力，但保持图标的明确焦点。将插图设置在纯白色背景上。最终结果必须清晰、干净且矢量友好，具有锐利的边缘，并且没有纹理或栅格效果。方形纵横比。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "illustration",
+        "retro",
+        "vehicle"
+      ],
+      "coverImage": "images/173.jpeg"
+    },
+    {
+      "id": 172,
+      "slug": "prompt-172",
+      "title": "棱柱形水晶",
+      "source": {
+        "name": "@alban_gz",
+        "url": "https://x.com/alban_gz/status/1938553802400899205"
+      },
+      "images": [
+        "images/172.jpeg",
+        "images/172-2.jpeg"
+      ],
+      "prompts": [
+        "Recreate this image using the parameters of the JSON provided.\n{\n  \"style_transfer\": {\n    \"name\": \"Prismatic Crystal\",\n    \"description\": \"Applies a highly realistic prismatic crystal style to any object, using precise light dispersion and photographic clarity. Ideal for adding a premium, gem-like finish to metallic or structured forms.\",\n    \"style_attributes\": {\n      \"surface_texture\": \"polished faceted crystal, sharp and clean edges, flawless transparency\",\n      \"lighting\": \"soft studio lighting with clear specular highlights and smooth ambient shadows\",\n      \"color_palette\": [\"sapphire blue\", \"electric cyan\", \"sunset amber\", \"violet\", \"magenta\", \"neutral white\"],\n      \"material\": \"dense optical glass or cut gemstone with prismatic inner reflections\",\n      \"effects\": [\n        \"realistic spectral dispersion\",\n        \"micro-refractions along edges\",\n        \"soft caustics on adjacent surfaces\",\n        \"lens-sharp gloss finish\",\n        \"subtle light blooming in high contrast areas\"\n      ],\n      \"contrast\": \"balanced with high edge definition and natural depth falloff\"\n    },\n    \"application_method\": {\n      \"blend_mode\": \"photographic overlay\",\n      \"intensity\": 1.0,\n      \"masking\": \"precise masking to preserve structure and cast shadows\",\n      \"edge_enhancement\": \"controlled sharpening for facets only\",\n      \"preserve_original_shape\": true,\n      \"realism_priority\": true,\n      \"depth_mapping\": true,\n      \"chromatic_aberration_limit\": \"minimal\"\n    }\n  }\n}",
+        "使用提供的 JSON 的参数重新创建此图像。\n{\n“style_transfer”：{\n“name”： “棱柱晶体”，\n“description”： “使用精确的光扩散和照片清晰度，将高度逼真的棱柱形水晶样式应用于任何对象。非常适合为金属或结构化形式添加优质的宝石般的饰面。\n“style_attributes”：{\n“surface_texture”： “抛光的刻面水晶，锋利干净的边缘，无瑕的透明度”，\n“lighting”： “柔和的工作室照明，具有清晰的镜面高光和平滑的环境阴影”，\n“color_palette”： [“宝石蓝”， “电青色”， “日落琥珀色”， “紫罗兰色”， “品红色”， “中性白”]，\n“material”： “密集的光学玻璃或切割宝石，具有棱柱形内部反射”，\n“effects”： [\n“真实光谱色散”，\n“沿边缘的微折射”，\n“相邻曲面上的软焦散”，\n“镜片般锐利的光泽饰面”，\n“高对比度区域中的微妙光晕”\n],\n“contrast”： “平衡，边缘清晰度高，深度衰减自然”\n    },\n“application_method”： {\n“blend_mode”： “摄影叠加”，\n“intensity”：1.0、\n“masking”： “精确蒙版以保留结构并投射阴影”，\n“edge_enhancement”： “仅针对小平面的受控锐化”，\n“preserve_original_shape”： true，\n“realism_priority”：true、\n“depth_mapping”：true、\n“chromatic_aberration_limit”： “最小”\n    }\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "minimalist",
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/172.jpeg"
+    },
+    {
+      "id": 171,
+      "slug": "prompt-171",
+      "title": "霓虹灯品牌重新构想",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1938363131442405631"
+      },
+      "images": [
+        "images/171.jpeg",
+        "images/171-2.jpeg",
+        "images/171-3.png",
+        "images/171-4.jpeg"
+      ],
+      "prompts": [
+        "Create a cinematic advertisement for “[PRODUCT NAME]” — use bioluminescent neon lighting that matches the brand’s visual identity — place the product at the center of the scene with surreal, minimalistic composition — automatically adapt the environment to reflect the product’s nature (e.g. tech, fragrance, luxury, automotive, beauty) — integrate the brand’s actual logo in high fidelity — generate a short, powerful 3-word tagline that fits the brand’s tone — long exposure lighting effects — dramatic shadows — ultra-sharp focus — dark or ambient background — aspect ratio 2:3 or 1:1 — ultra-HD resolution",
+        "为“[产品名称]”创建电影广告 — 使用与品牌视觉形象相匹配的生物发光霓虹灯 — 以超现实、简约的构图将产品置于场景中心——自动调整环境以反映产品的性质（例如科技、香水、奢侈品、汽车、美容） — 以高保真度集成品牌的实际徽标 — 生成一个简短的、 符合品牌基调的强大 3 字标语 — 长时间曝光、灯光效果 — 戏剧性的阴影 — 超清晰焦点 — 黑暗或环境背景 — 纵横比 2：3 或 1：1 — 超高清分辨率"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "minimalist",
+        "nature",
+        "neon",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/171.jpeg"
+    },
+    {
+      "id": 170,
+      "slug": "prompt-170",
+      "title": "新卡通风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1938518646072004759"
+      },
+      "images": [
+        "images/170.png",
+        "images/170-2.jpeg",
+        "images/170-3.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into the Foster’s Home for Imaginary Friends cartoon style. Use bold outlines, flat shapes, and vivid solid colors. Characters should have simplified, playful designs with exaggerated expressions and unique silhouettes. Keep the background minimal or stylized with flat patterns or textures. The result should look like a frame from a 2000s Cartoon Network show with whimsical, graphic charm.",
+        "将此图像转换为 Foster's Home for Imaginary Friends 卡通风格。使用粗体轮廓、平面形状和鲜艳的纯色。角色应该具有简化、俏皮的设计，带有夸张的表情和独特的轮廓。保持背景最小或使用平面图案或纹理进行风格化。结果应该看起来像 2000 年代卡通网络节目中的帧，具有异想天开的图形魅力。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "minimalist",
+        "vehicle"
+      ],
+      "coverImage": "images/170.png"
+    },
+    {
+      "id": 169,
+      "slug": "prompt-169",
+      "title": "微型透明胶囊",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1938299520019734676"
+      },
+      "images": [
+        "images/169.png",
+        "images/169-2.jpeg",
+        "images/169-3.jpeg",
+        "images/169-4.jpeg",
+        "images/169-5.jpeg"
+      ],
+      "prompts": [
+        "Close-up, A hand holding a transparent capsule, inside it is a miniature model of [character name], wearing [their iconic outfit and accessories]. The character is posed in a [specific, expressive or dynamic pose], interacting with the inner surface of the capsule, as if they are frozen or confined inside. Hyper-realistic, cinematic, studio lighting setup, photographed with a macro lens.",
+        "特写，一只手拿着一个透明的胶囊，里面是一个 [角色名称] 的微型模型，穿着 [他们的标志性服装和配饰]。角色以 [特定、富有表现力或动态的姿势] 摆姿势，与胶囊的内表面互动，就好像他们被冻结或限制在里面一样。超逼真、电影般的工作室照明设置，使用微距镜头拍摄。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "character",
+        "fashion",
+        "logo",
+        "photography"
+      ],
+      "coverImage": "images/169.png"
+    },
+    {
+      "id": 168,
+      "slug": "prompt-168",
+      "title": "水果蜡烛",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1938272260726350172"
+      },
+      "images": [
+        "images/168.png",
+        "images/168-2.jpeg"
+      ],
+      "prompts": [
+        "A minimal still life of a round glass candle filled with [fruit], labeled “[SCENT NAME]”, placed on elegant white silk fabric. The candle glass is [glass color], and the wax matches the fruit color. The scene is softly lit by natural daylight with subtle shadows and smooth highlights. Hyperrealistic texture, clean aesthetic, top-down view, styled like high-end product photography.",
+        "一个装满 [水果] 的圆形玻璃蜡烛的极简静物，标有“[SCENT NAME]”，放在优雅的白色丝绸织物上。蜡烛玻璃为【玻璃色】，蜡与水果色相配。该场景由自然日光柔和照亮，具有微妙的阴影和平滑的高光。超写实的质感，简洁的美感，自上而下的视角，风格像高端产品摄影。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "landscape",
+        "minimalist",
+        "nature",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/168.png"
+    },
+    {
+      "id": 167,
+      "slug": "prompt-167",
+      "title": "液态金属设计产品",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1938203557771260064"
+      },
+      "images": [
+        "images/167.jpeg",
+        "images/167-2.png"
+      ],
+      "prompts": [
+        "create image with 1:1 ratio \nretexture the photo I attached with the following json \n{   \"style_name\": \"hermes_subtle_specular_gradient\",   \"background\": {     \"type\": \"solid\",     \"color\": \"#000000\",     \"light_reflection\": \"none\"   },   \"base_material\": {     \"type\": \"polished_metal\",     \"color\": \"#B0B0B0\",     \"finish\": \"glossy\",     \"reflectivity\": 0.75,     \"surface_variation\": {       \"micro_noise\": 0.005,       \"brushed_direction\": \"none\"     }   },   \"highlight_strategy\": {     \"mode\": \"localized_specular_enhancement\",     \"trigger\": \"light-facing curved planes and direct lit faces\",     \"color_gradient\": [\"#121A28\", \"#3D4C6B\", \"#8c71b7\", \"#4d21cd\"],     \"gradient_type\": \"fluid_blend\",     \"intensity_curve\": \"ease-out from highlight center\",     \"falloff\": 0.8,     \"blend_mode\": \"soft_light\",     \"saturation_level\": 0.4,     \"coverage_ratio\": 0.2,     \"transition_smoothness\": 0.95   },   \"lighting\": {     \"scene_type\": \"high-control studio\",     \"key_light\": {       \"intensity\": 1.0,       \"color\": \"#FFFFFF\",       \"angle\": \"35° above and side\",       \"softness\": 0.6     },     \"fill_light\": {       \"enabled\": false     },     \"rim_light\": {       \"enabled\": false     },     \"reflection_behavior\": {       \"mirrored_zones\": \"limited to high exposure zones\",       \"glow_color\": \"applied from gradient with low saturation\"     }   },   \"specular_color_behavior\": {     \"base_surface\": \"metallic neutral\",     \"highlight_zones\": \"low-saturation chromatic reflection\",     \"edge_bleed\": \"minimal\",     \"inner_glow\": 0.1   },   \"detail_features\": {     \"engraved_elements\": {       \"type\": \"precise deboss\",       \"lighting_response\": \"low bounce\",       \"shadow_edge\": \"#222222\",       \"rim_light_tint\": \"#888888\"     }   },   \"application_targets\": [     \"object product photography\",     \"3D icons with selective lighting\",     \"branding renders\",     \"luxury UI component styling\"   ],   \"visual_effect_notes\": {     \"mood\": \"understated luxury, technical precision, controlled emotion\",     \"realism\": \"stylized physical logic\",     \"focus\": \"refined colored specular only on light-facing curved surfaces with fluid-like gradient transitions\"   } }",
+        "以 1：1 的比例创建图像\n我用以下 json 对我附加的照片进行 retexture\n{ “style_name”： “hermes_subtle_specular_gradient”， “background”： { “type”： “solid”， “color”： “#000000”， “light_reflection”： “none” }， “base_material”： { “type”： “polished_metal”， “color”： “#B0B0B0”， “finish”： “glossy”， “reflectivity”： 0.75， “surface_variation”： { “micro_noise”： 0.005， “brushed_direction”： “none” } }， “highlight_strategy”： { “mode”： “localized_specular_enhancement”， “trigger”： “朝光曲面和直接照明 faces“， ”color_gradient“： [”#121A28“， ”#3D4C6B“， ”#8c71b7“， ”#4d21cd“]， ”gradient_type“： ”fluid_blend“， ”intensity_curve“： ”从高光中心缓出“， ”衰减“： 0.8， ”blend_mode“： ”soft_light“， ”saturation_level“： 0.4， ”coverage_ratio“： 0.2， ”transition_smoothness“： 0.95 }， ”lighting“： { ”scene_type“： ”high-control studio“， ”key_light“： { ”intensity“：1.0， “color”： “#FFFFFF”， “angle”： “上侧 35°”， “柔和度”： 0.6 }， “fill_light”： { “enabled”： false }， “rim_light”： { “enabled”： false }， “reflection_behavior”： { “mirrored_zones”： “仅限于高曝光区域”， “glow_color”： “从低饱和度渐变应用” } }， “specular_color_behavior”： { “base_surface”： “金属中性”， “highlight_zones”： “低饱和度色度 reflection“， ”edge_bleed“： ”minimal“， ”inner_glow“： 0.1 }， ”detail_features“： { ”engraved_elements“： { ”type“： ”精确凹陷“， ”lighting_response“： ”低反弹“， ”shadow_edge“： ”#222222“， ”rim_light_tint“： ”#888888“ } }， ”application_targets“： [ ”对象产品 photography“， ”具有选择性照明的 3D 图标“， ”品牌渲染“， ”豪华 UI 组件样式“ ]， ”visual_effect_notes“： { ”mood“： ”低调奢华、技术精确、受控情感“， ”realism“： ”风格化的物理逻辑“， ”focus“： ”仅在具有流体般渐变过渡的面向光线的曲面上优化彩色镜面反射“ } }"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "photography",
+        "product",
+        "ui"
+      ],
+      "coverImage": "images/167.jpeg"
+    },
+    {
+      "id": 166,
+      "slug": "prompt-166",
+      "title": "几何禅",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1938330188414132727"
+      },
+      "images": [
+        "images/166.png",
+        "images/166-2.png",
+        "images/166-3.jpeg"
+      ],
+      "prompts": [
+        "[SUBJECT] illustrated in a Geometric Zen Tranquility style, where simplicity and balance are key. Utilize clean lines, basic shapes, and a serene color palette of [COLOR1] and [COLOR2] to evoke a sense of peace and harmony.",
+        "[主题] 以几何禅宗宁静风格插图，其中简单和平衡是关键。利用简洁的线条、基本形状以及 [COLOR1] 和 [COLOR2] 的宁静调色板来唤起和平与和谐的感觉。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "illustration"
+      ],
+      "coverImage": "images/166.png"
+    },
+    {
+      "id": 165,
+      "slug": "prompt-165",
+      "title": "用气泡膜覆盖表情符号",
+      "source": {
+        "name": "@Anima_Labs",
+        "url": "https://x.com/Anima_Labs/status/1938503818578178146"
+      },
+      "images": [
+        "images/165.png",
+        "images/165-2.png"
+      ],
+      "prompts": [
+        "A hyper-realistic 3D render of the emoji [❤️‍🔥], entirely wrapped in transparent bubble wrap. The plastic is tightly fitted, with clearly visible air-filled bubbles creating overlaid reflections and soft distortions of the emoji underneath. The wrap has a glossy, crinkled texture that catches the light in detailed highlights. Set against a soft, neutral grey background with subtle shadows. Studio lighting should emphasize the tactile quality of the bubble wrap and the surreal effect it creates. Whimsical, satisfying, and visually clean.",
+        "表情符号 [ ❤️‍🔥 ] 的超逼真 3D 渲染 ，完全包裹在透明气泡膜中。塑料紧密贴合，清晰可见的充满空气的气泡在下面产生叠加的反射和表情符号的柔和扭曲。包裹具有有光泽的褶皱纹理，可在细节高光中捕捉光线。以柔和的中性灰色为背景，带有微妙的阴影。工作室照明应强调气泡膜的触觉质量及其产生的超现实效果。异想天开、令人满意且视觉上干净。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "emoji"
+      ],
+      "coverImage": "images/165.png"
+    },
+    {
+      "id": 164,
+      "slug": "prompt-164",
+      "title": "将表情符号变成纸板",
+      "source": {
+        "name": "@Anima_Labs",
+        "url": "https://x.com/Anima_Labs/status/1938152354064609780"
+      },
+      "images": [
+        "images/164.png",
+        "images/164-2.png"
+      ],
+      "prompts": [
+        "Ultra high-resolution 3D render of the emoji [🥹], meticulously recreated as a realistic cardboard sculpture. The object is crafted from corrugated brown cardboard, featuring clearly defined fluted edges, visible layering, and rough kraft paper textures. Close-up studio",
+        "表情符号 [ 🥹 ] 的超高分辨率 3D 渲染 ，精心重建为逼真的纸板雕塑。该物品由棕色瓦楞纸板制成，具有清晰的凹槽边缘、可见的层次和粗糙的牛皮纸纹理。特写工作室"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "emoji",
+        "paper-craft",
+        "sculpture",
+        "vehicle"
+      ],
+      "coverImage": "images/164.png"
+    },
+    {
+      "id": 163,
+      "slug": "prompt-163",
+      "title": "半透明玻璃物品ASMR",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1936825522417533274"
+      },
+      "images": [
+        "images/163.jpeg",
+        "images/163-2.jpeg",
+        "images/163-3.jpeg",
+        "images/163-4.jpeg"
+      ],
+      "prompts": [
+        "Hyper-realistic [fruit name] made of translucent glass, smooth, rounded surface with fine air bubbles inside, placed on a clean surface, sharp lighting with strong reflections and highlights, minimal background, photorealistic, glossy texture, 3D render style, crystal-like appearance, soft shadows, macro photography",
+        "由半透明玻璃制成的超写实 [水果名称]，光滑、圆润的表面，内部有细小的气泡，放置在干净的表面上，具有强烈反射和高光的清晰照明，最小的背景，照片级写实，有光泽的纹理，3D 渲染样式，水晶般的外观，柔和的阴影，微距摄影"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "说明：在几秒钟内使用 GPT-4o 将任何东西重新设计成半透明玻璃，然后使用这些图像创建 ASMR 视频",
+      "tags": [
+        "minimalist",
+        "photography"
+      ],
+      "coverImage": "images/163.jpeg"
+    },
+    {
+      "id": 162,
+      "slug": "prompt-162",
+      "title": "超现实主义蒸汽波",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1936703218827817358"
+      },
+      "images": [
+        "images/162.png",
+        "images/162-2.jpeg"
+      ],
+      "prompts": [
+        "[SUBJECT] in a Surrealist Vaporwave collage. Combine elements of classical sculpture, 80s retrofuturism, and Japanese cityscapes. Use pastel shades of [COLOR1] and [COLOR2] with hints of neon",
+        "[主题] 在超现实主义蒸汽波拼贴画中。结合古典雕塑、80 年代复古未来主义和日本城市景观的元素。使用 [COLOR1] 和 [COLOR2] 的柔和色调，并带有淡淡的霓虹灯"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "landscape",
+        "neon",
+        "retro",
+        "sculpture"
+      ],
+      "coverImage": "images/162.png"
+    },
+    {
+      "id": 161,
+      "slug": "prompt-161",
+      "title": "物品纹理处理",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1936851399289037108"
+      },
+      "images": [
+        "images/161.png",
+        "images/161-2.jpeg"
+      ],
+      "prompts": [
+        "retexture the image attached based on the JSON below:\n{\n  \"style_name\": \"Transparent Studio Render\",\n  \"visual_rules\": {\n    \"form\": {\n      \"shape\": \"preserve original object shape\",\n      \"outline\": \"no outlines, use smooth geometry transitions and bevels\"\n    },\n    \"lighting\": {\n      \"style\": \"studio-style 3-point lighting or soft HDRI setup\",\n      \"highlight\": \"subtle specular highlights for semi-matte plastic or coated surfaces\",\n      \"shadow\": \"soft drop shadow directly beneath the object, cast on a translucent floor plane\"\n    },\n    \"texture\": {\n      \"surface\": \"smooth or lightly textured based on object, clean shader setup with minimal noise\",\n      \"branding\": \"bold and high-contrast, treated as printed decals or sticker-style labels\"\n    },\n    \"material\": {\n      \"finish\": \"semi-matte or satin shader, mimicking printed plastic or coated materials\"\n    },\n    \"color_handling\": {\n      \"strategy\": \"make the object's primary color the focal point\",\n      \"enhancement\": \"slightly boosted saturation and contrast for clean product visualization\"\n    },\n    \"background\": {\n      \"type\": \"fully transparent (alpha channel)\",\n      \"shadow\": \"optional soft drop shadow directly beneath the object to ground it visually\"\n    }\n  },\n  \"rendering\": {\n    \"camera_angle\": \"centered front view or slightly elevated for dimensional clarity\",\n    \"depth_of_field\": \"neutral or slightly shallow to keep object fully sharp\",\n    \"background_blur\": \"none, background remains transparent\"\n  }\n}",
+        "根据以下 JSON 对附加的图片进行重新纹理处理：\n{\n“style_name”： “透明工作室渲染”，\n“visual_rules”： {\n“form”： {\n“shape”： “保留原始对象形状”，\n“outline”： “无轮廓，使用平滑的几何过渡和斜面”\n    },\n“照明”： {\n“style”： “工作室风格的 3 点光照或柔和 HDRI 设置”，\n“highlight”： “半哑光塑料或涂层表面的细微镜面反射高光”，\n“shadow”： “对象正下方的柔和投影，投射在半透明地板平面上”\n    },\n“texture”： {\n“surface”： “基于对象的平滑或轻微纹理，干净的着色器设置，噪点最小”，\n“branding”： “粗体且对比度高，被视为印刷贴花或贴纸式标签”\n    },\n“material”： {\n“finish”： “半哑光或缎面着色器，模拟打印塑料或涂层材质”\n    },\n“color_handling”： {\n“strategy”： “将对象的原色作为焦点”，\n“enhancement”： “略微提高饱和度和对比度，实现清晰的产品可视化”\n    },\n“背景”： {\n“type”： “完全透明（Alpha 通道）”，\n“shadow”： “可选的软投影正下方，使其在视觉上接地”\n    }\n  },\n“渲染”： {\n“camera_angle”： “居中前视图或略微升高以提高尺寸清晰度”，\n“depth_of_field”： “中性或稍浅，以保持物体完全清晰”，\n“background_blur”： “无，背景保持透明”\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "nature",
+        "paper-craft",
+        "product"
+      ],
+      "coverImage": "images/161.png"
+    },
+    {
+      "id": 160,
+      "slug": "prompt-160",
+      "title": "新动漫风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1937069198921924968"
+      },
+      "images": [
+        "images/160.png",
+        "images/160-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into an over-the-top anime illustration in the style of Trigger / Gainax. Use exaggerated expressions, wild motion lines, and hyperdynamic poses. The anatomy should be fluid and distorted for emphasis — limbs stretching or snapping into action. Add speed lines, explosive backgrounds, and dramatic lighting effects. Integrate onomatopoeia or stylized text for extra chaos. Colors should be bold, saturated, and contrasting. The result should feel like a freeze frame from Kill la Kill or FLCL, mid-action, full of energy and visual impact.",
+        "将此图像转换为 Trigger / Gainax 风格的夸张动漫插图。使用夸张的表情、狂野的运动线条和超动态姿势。解剖结构应该是流畅的，并且为了强调而扭曲——四肢伸展或突然行动起来。添加速度线、爆炸性背景和戏剧性的灯光效果。集成拟声词或风格化文本以增加混乱。颜色应大胆、饱和且具有对比性。结果应该感觉像是 Kill la Kill 或 FLCL 的定格，在动作中，充满活力和视觉冲击力。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "illustration"
+      ],
+      "coverImage": "images/160.png"
+    },
+    {
+      "id": 159,
+      "slug": "prompt-159",
+      "title": "渲染宝石",
+      "source": {
+        "name": "@alban_gz",
+        "url": "https://x.com/alban_gz/status/1936820704713875818"
+      },
+      "images": [
+        "images/159.jpeg"
+      ],
+      "prompts": [
+        "Recreate this image using the pamareters of the JSON provided.\n{\n  \"name\": \"Gemstone Render\",\n  \"object\": {\n    \"type\": \"auto\",\n    \"detected_color\": \"auto\",\n    \"form\": \"realistic, natural form preserved\",\n    \"material\": \"crystal or faceted gemstone glass\",\n    \"surface\": \"precision-cut facets, sharp reflections\",\n    \"transparency\": \"high clarity with light refraction\",\n    \"internal_features\": \"color depth, internal shimmer, and light dispersion\"\n  },\n  \"color_and_light\": {\n    \"primary_color\": \"{detected_color}\",\n    \"highlight_effects\": \"specular highlights, gemstone brilliance, caustics\",\n    \"lighting_setup\": \"studio lighting with white or soft background\",\n    \"metallic_accents\": {\n      \"enabled\": true,\n      \"material\": \"gold or chrome\",\n      \"application\": \"rim, stem, or edge detailing\"\n    }\n  },\n  \"style\": {\n    \"artistic_style\": [\n      \"photorealistic 3D render\",\n      \"Gemstone Render Style\",\n      \"luxury object visualization\"\n    ],\n    \"design_language\": [\n      \"faceted precision modeling\",\n      \"jewelry-like rendering\",\n      \"optical depth and brilliance\"\n    ]\n  },\n  \"technical_details\": {\n    \"render_engine\": [\n      \"Blender with Cycles\",\n      \"Cinema 4D + Redshift/Octane\"\n    ],\n    \"rendering_techniques\": [\n      \"physically-based rendering (PBR)\",\n      \"ray tracing\",\n      \"global illumination\"\n    ],\n    \"resolution\": \"ultra high-res (4K–8K)\",\n    \"post_processing\": [\n      \"subtle glow\",\n      \"enhanced reflections\",\n      \"color-preserving contrast boost\"\n    ]\n  }",
+        "使用提供的 JSON 的 pamareters 重新创建此图像。\n{\n“name”： “宝石渲染”，\n“对象”： {\n“type”： “auto”， //类型\n“detected_color”： “auto”，\n“form”： “保留真实、自然的形式”，\n“material”： “水晶或刻面宝石玻璃”，\n“surface”： “精确切割的刻面，清晰的反射”，\n“transparency”： “高清晰度，光线折射”，\n“internal_features”： “颜色深度、内部微光和光色散”\n  },\n“color_and_light”： {\n“primary_color”： “{detected_color}”，\n“highlight_effects”： “镜面高光、宝石亮度、焦散”，\n“lighting_setup”： “白色或柔和背景的工作室照明”，\n“metallic_accents”： {\n“enabled”： true 和\n“material”： “金或铬”，\n“application”： “边缘、茎或边缘细节”\n    }\n  },\n“样式”： {\n“artistic_style”：[\n“逼真的 3D 渲染”，\n“Gemstone Render Style”（宝石渲染样式）、\n“奢侈品对象可视化”\n],\n“design_language”：[\n“faceted precision modeling”，\n“珠宝般的渲染”，\n“光学深度和亮度”\n    ]\n  },\n“technical_details”： {\n“render_engine”：[\n“带循环的 Blender”，\n“Cinema 4D + Redshift/Octane”\n],\n“rendering_techniques”：[\n“基于物理的渲染 （PBR）”，\n“光线追踪”，\n“全局照明”\n],\n“resolution”： “超高分辨率 （4K–8K）”，\n“post_processing”：[\n“微妙的光芒”，\n“增强反射”，\n“保色对比度提升”\n    ]\n  }"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/159.jpeg"
+    },
+    {
+      "id": 158,
+      "slug": "prompt-158",
+      "title": "品牌3D卡通动物角色",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1937010045062959468"
+      },
+      "images": [
+        "images/158.png",
+        "images/158-2.jpeg"
+      ],
+      "prompts": [
+        "A high-quality 3D cartoon animal character inspired by [Brand Name], with large round eyes and an innocent, friendly expression. The character wears a knitted sweater featuring the brand name in bold letters. It sits confidently atop a futuristic vehicle shaped like a product from the brand, fully inspired by the brand’s design language and covered in racing stickers and symbolic brand logos. The scene is set inside a maintenance workshop that showcases Stone Age-era versions of the brand's products. The background blends the brand’s visual identity colors. The design must be highly detailed, with Pixar-style lighting and realistic textures for the character, fabric, and vehicle. Format: full-body, in a dynamic pose, rendered in 4K CGI.",
+        "受 [品牌名称] 启发的高品质 3D 卡通动物角色，拥有圆圆的大眼睛和天真友好的表情。该角色穿着一件针织毛衣，上面印有粗体字的品牌名称。它自信地坐在一辆形状像该品牌产品的未来主义汽车上，完全受到品牌设计语言的启发，并覆盖着赛车贴纸和象征性的品牌标志。场景设置在一个维修车间内，该车间展示了该品牌产品的石器时代版本。背景融合了品牌的视觉识别颜色。设计必须非常详细，具有皮克斯风格的照明和角色、织物和车辆的逼真纹理。格式：全身，动态姿势，以 4K CGI 渲染。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "branding",
+        "cartoon",
+        "character",
+        "futuristic",
+        "landscape",
+        "logo",
+        "paper-craft",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/158.png"
+    },
+    {
+      "id": 157,
+      "slug": "prompt-157",
+      "title": "最小天气小部件",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1937118859083047137"
+      },
+      "images": [
+        "images/157.jpeg",
+        "images/157-2.jpeg"
+      ],
+      "prompts": [
+        "create image with 1:1 ratio \nsurreal minimal aesthetic, airplane window frame on subtle gradient backdrop with same color, through the oval window showing random iconic landmark scenery of [Country Name], an overlay weather ui interface on the center of window, from top to bottom, contain the small weather icon, huge temperatures with elegant light weight font, and small location tag beneath it, the bottom is the country name, generate with extreme weathers, the window will affect by the weather, the color combo of subtle gradient backdrop is resonate with the weather, natural lighting, soft shadows, subtle reflections on glass, great negative space",
+        "以 1：1 的比例创建图像\n超现实的极简美学，飞机窗框在微妙的渐变背景上，同色系，通过椭圆形窗口随机展示【国家名称】的标志性地标风景，窗口中央叠加天气 UI 界面，从上到下，包含小天气图标，巨大的温度搭配优雅的轻量级字体，下方有小位置标签， 底部是国名，在极端天气下生成，窗户会受到天气的影响，微妙的渐变背景的颜色组合与天气产生共鸣，自然光，柔和的阴影，玻璃上的微妙反射，巨大的负空间"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "logo",
+        "minimalist",
+        "nature",
+        "typography",
+        "ui"
+      ],
+      "coverImage": "images/157.jpeg"
+    },
+    {
+      "id": 156,
+      "slug": "prompt-156",
+      "title": "作为家具的著名地标",
+      "source": {
+        "name": "@zeng_wt",
+        "url": "https://x.com/zeng_wt/status/1936743124522750336"
+      },
+      "images": [
+        "images/156.jpeg",
+        "images/156-2.jpeg"
+      ],
+      "prompts": [
+        "The [LANDMARK - Statue of Liberty/Eiffel Tower/Big Ben] perfectly carved and functional as a [FURNITURE_PIECE - lamp/bookshelf/coffee table], living room setting, normal scale furniture, photorealistic detail.",
+        "[LANDMARK - 自由女神像/埃菲尔铁塔/大本钟]雕刻完美，功能强大，就像一个[FURNITURE_PIECE - 灯/书架/咖啡桌]，客厅设置，正常比例的家具，逼真的细节。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "photography",
+        "sculpture",
+        "vehicle"
+      ],
+      "coverImage": "images/156.jpeg"
+    },
+    {
+      "id": 155,
+      "slug": "prompt-155",
+      "title": "自己的国家地标时尚杂志",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1936802168318910673"
+      },
+      "images": [
+        "images/155.png",
+        "images/155-2.jpeg"
+      ],
+      "prompts": [
+        "a luxurious fashion magazine cover designed in the style of [COUNTRY], blending iconic landmarks, cultural symbols, and local fashion aesthetics. The layout mimics high-end editorial design, with headlines inspired by the country’s language, trends, and lifestyle. Sophisticated, cinematic lighting, vertical 9:16 format, ultra-detailed, Vogue-level elegance",
+        "以 [COUNTRY] 风格设计的豪华时尚杂志封面，融合了标志性地标、文化符号和当地时尚美学。布局模仿高端编辑设计，标题的灵感来自该国的语言、趋势和生活方式。精致的电影级灯光，垂直 9：16 格式，超细节，Vogue 级别的优雅"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "fashion",
+        "logo"
+      ],
+      "coverImage": "images/155.png"
+    },
+    {
+      "id": 154,
+      "slug": "prompt-154",
+      "title": "五颜六色的针织",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1936665222271615107"
+      },
+      "images": [
+        "images/154.jpeg",
+        "images/154-2.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic, artistic rendering of a [OBJECT] entirely wrapped in colorful, tightly woven yarn and embroidery threads. The surface is covered in intricate, detailed textile patterns—knit, braided, and woven in a variety of textures. Each section of the [OBJECT] is segmented with vivid, high-saturation colors including electric blue, bright orange, vivid green, magenta, and golden yellow. The yarn follows the contours of the [OBJECT], highlighting its shape with layered embroidery. The scene is lit dramatically, with a soft spotlight casting shadows to emphasize the 3D depth and tactile surface. The background is a solid, dark gradient to draw full focus to the texture and color. The style is a blend of surrealism and fiber art, showcasing extreme detail and depth",
+        "一个 [OBJECT] 的超现实主义、艺术渲染，完全包裹在五颜六色、紧密编织的纱线和绣花线中。表面覆盖着复杂、细致的纺织图案 - 针织、编织和编织，具有各种纹理。[OBJECT] 的每个部分都用鲜艳、高饱和度的颜色分割，包括电光蓝、亮橙色、鲜艳的绿色、品红色和金黄色。纱线遵循 [OBJECT] 的轮廓，以分层刺绣突出其形状。场景被戏剧性地照亮，柔和的聚光灯投下阴影以强调 3D 深度和触觉表面。背景是一个纯色的深色渐变，用于将全部焦点吸引到纹理和颜色上。风格融合了超现实主义和纤维艺术，展示了极端的细节和深度"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "landscape",
+        "nature"
+      ],
+      "coverImage": "images/154.jpeg"
+    },
+    {
+      "id": 153,
+      "slug": "prompt-153",
+      "title": "霓虹灯线框",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1936741480972079563"
+      },
+      "images": [
+        "images/153.png",
+        "images/153-2.jpeg"
+      ],
+      "prompts": [
+        "A neon wireframe visualization of a [subject], traced in glowing [color1] and [color2] vector lines. Suspended in a digital void, the figure is surrounded by speed trails, motion blur, and shifting geometric shadows, evoking a sense of kinetic energy and futuristic momentum.",
+        "[主体] 的霓虹灯线框可视化，以发光的 [color1] 和 [color2] 矢量线描摹。这个人物悬浮在数字虚空中，周围环绕着速度轨迹、运动模糊和不断变化的几何阴影，唤起了一种动能和未来主义的动力。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "neon",
+        "portrait"
+      ],
+      "coverImage": "images/153.png"
+    },
+    {
+      "id": 152,
+      "slug": "prompt-152",
+      "title": "新动漫风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1936716854090760197"
+      },
+      "images": [
+        "images/152.png",
+        "images/152-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a 1960s Tezuka-style illustration. Use big, rounded expressive eyes with bright highlights. Simplify the anatomy with soft, rounded limbs and clean linework. Avoid detailed textures — focus on smooth color fills and strong silhouettes. The final image should resemble a vintage anime frame from Astro Boy, with an optimistic, futuristic feel.",
+        "将此图像转换为 1960 年代手冢风格的插图。使用大而圆、富有表现力的眼睛，并带有明亮的高光。通过柔软、圆润的四肢和简洁的线条简化解剖结构。避免细节纹理 - 专注于平滑的颜色填充和强烈的轮廓。最终的图像应该类似于 Astro Boy 的老式动漫框架，具有乐观、未来主义的感觉。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "illustration",
+        "retro"
+      ],
+      "coverImage": "images/152.png"
+    },
+    {
+      "id": 151,
+      "slug": "prompt-151",
+      "title": "Neoglo风格Logo",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1936744152366288926"
+      },
+      "images": [
+        "images/151.jpeg",
+        "images/151-2.png"
+      ],
+      "prompts": [
+        "Design a modern logo in NeoGradient Soft Tech style for a fictional startup called “NAME” in the “[INDUSTRY TYPE]” industry.\n\nThe logo must include:\n•A unique abstract icon\n•A clean, bold sans-serif logotype\n•Smooth glowing gradients blending vibrant colors like blue, purple, pink, orange, and teal\n•Seamless harmony between symbol and text\n•Minimalist, futuristic composition\n•On a pure black background\n•1:1 aspect ratio — ultra-HD\n\nThe logo should feel creative, modern, and ready for a bold digital brand.",
+        "为“[INDUSTRY TYPE]”行业中名为 “NAME” 的虚构初创公司设计一个 NeoGradient Soft Tech 风格的现代标志。\n\n徽标必须包含：\n•独特的抽象图标\n•干净、大胆的无衬线标识\n•平滑的发光渐变，混合了蓝色、紫色、粉红色、橙色和蓝绿色等鲜艳的颜色\n•符号和文本之间的无缝协调\n•极简主义、未来主义的构图\n•在纯黑色背景上\n•1：1 纵横比 — 超高清\n\n徽标应该具有创意、现代感，并为大胆的数字品牌做好准备。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "futuristic",
+        "logo",
+        "minimalist"
+      ],
+      "coverImage": "images/151.jpeg"
+    },
+    {
+      "id": 150,
+      "slug": "prompt-150",
+      "title": "乙烯基玩具",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1937104120097407069"
+      },
+      "images": [
+        "images/150.png",
+        "images/150-2.png",
+        "images/150-3.jpeg",
+        "images/150-4.jpeg"
+      ],
+      "prompts": [
+        "A comic-style caricature illustration of [subject], with an oversized head and expressive eyes, rendered in a hyper-realistic vinyl toy aesthetic. The character features exaggerated proportions, glossy textures, and playful details, blending caricature art with collectible figure charm.",
+        "[主题]的漫画风格漫画插图，具有超大的头部和富有表现力的眼睛，以超逼真的乙烯基玩具美学呈现。该角色具有夸张的比例、光滑的纹理和俏皮的细节，将漫画艺术与收藏人物魅力融为一体。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "character",
+        "illustration",
+        "portrait",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/150.png"
+    },
+    {
+      "id": 149,
+      "slug": "prompt-149",
+      "title": "Gorillaz风格角色",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1936834901552111768"
+      },
+      "images": [
+        "images/149.png",
+        "images/149-2.jpeg"
+      ],
+      "prompts": [
+        "Create a stylized full-body portrait of [your subject] in the Gorillaz character aesthetic. Give the character an exaggeratedly lanky build with long, skinny legs and narrow arms. Use simplified, angular features and thick, bold outlines. Style the hair to be spiky, tousled, or exaggerated, in a non-natural color like [blue or green]. The eyes must be blank white with no pupils. Use flat, solid colors only. No gradients, shadows, or textures. Background should be a single flat color. Design must be vector friendly and print ready.",
+        "在 Gorillaz 角色美学中为 [您的主题] 创建风格化的全身肖像。给角色一个夸张的瘦长身材，长而瘦的腿和狭窄的手臂。使用简化的棱角分明的特征和粗体轮廓。将头发设计成尖尖的、凌乱的或夸张的，用非自然的颜色，如 [蓝色或绿色]。眼睛必须是空白的白色的，没有瞳孔。仅使用纯色。没有渐变、阴影或纹理。背景应为单一的平面颜色。设计必须对矢量友好并准备好打印。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "character",
+        "nature",
+        "portrait"
+      ],
+      "coverImage": "images/149.png"
+    },
+    {
+      "id": 148,
+      "slug": "prompt-148",
+      "title": "怀旧午后阳光",
+      "source": {
+        "name": "@BeanieBlossom",
+        "url": "https://x.com/BeanieBlossom/status/1936756146817372428"
+      },
+      "images": [
+        "images/148.jpeg",
+        "images/148-2.jpeg"
+      ],
+      "prompts": [
+        "a pillow fort in the backyard, shaded by a big old tree. Sunlight filters through the leaves, and a young boy and his golden retriever naps beside a tray of lemonade and cookies. Wind chimes tinkle gently in the breeze. Warm afternoon light, playful and nostalgic, children's book illustrated feeling",
+        "后院的一座枕头堡，被一棵大老树遮蔽。阳光透过树叶洒进来，一个小男孩和他的金毛猎犬在一盘柠檬水和饼干旁边打盹。风铃在微风中轻轻地叮叮当当。温暖的午后阳光，俏皮又怀旧，童书图画情怀"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/148.jpeg"
+    },
+    {
+      "id": 147,
+      "slug": "prompt-147",
+      "title": "玻璃变形海报",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1936950051856941470"
+      },
+      "images": [
+        "images/147.jpeg",
+        "images/147-2.jpeg"
+      ],
+      "prompts": [
+        "Design a cinematic brand poster featuring “[BRAND NAME]” — include a bold six-word slogan beneath — apply a 3D glass refraction effect that distorts part of the text or layout — incorporate the brand logo in the top corner — smooth shadows, glossy lighting, black extra-bold typography — clean modern background — high-resolution, 1:1 aspect ratio",
+        "设计一张带有“[BRAND NAME]”字样的电影式品牌海报 — 在下面包括一个粗体的六字标语 — 应用 3D 玻璃折射效果，使部分文本或布局失真 — 在右上角加入品牌徽标 — 平滑的阴影、有光泽的照明、黑色超粗体排版 — 干净的现代背景 — 高分辨率、1：1 的纵横比"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "poster",
+        "typography"
+      ],
+      "coverImage": "images/147.jpeg"
+    },
+    {
+      "id": 146,
+      "slug": "prompt-146",
+      "title": "全息叠加效果彩虹渐变",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1936892719202193900"
+      },
+      "images": [
+        "images/146.jpeg",
+        "images/146-2.png"
+      ],
+      "prompts": [
+        "Apply a holographic overlay effect on [SUBJECT/TEXT] — dreamy rainbow gradients with soft radial light reflections — smooth glossy surface, high contrast blending — iridescent hues like pink, teal, cyan, and purple — noise texture with soft light blend — subtle shadows and edge lighting to add depth — centered composition on a dark background — ultra-HD, 1:1 ratio, cinematic lighting",
+        "在 [主题/文本] 上应用全息叠加效果 — 梦幻般的彩虹渐变，柔和的径向光反射 — 光滑的光泽表面，高对比度混合 — 粉色、蓝绿色、青色和紫色等彩虹色 — 柔和光线混合的杂色纹理 — 微妙的阴影和边缘照明以增加深度 — 深色背景上的居中构图 — 超高清、1：1 比例、电影照明"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/146.jpeg"
+    },
+    {
+      "id": 145,
+      "slug": "prompt-145",
+      "title": "用自己的审美下棋",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1937064180017971501"
+      },
+      "images": [
+        "images/145.png",
+        "images/145-2.jpeg"
+      ],
+      "prompts": [
+        "A highly realistic vertical photograph of a traditional chessboard viewed from above, set against a textured surface inspired by [COUNTRY]’s artistic heritage. The chessboard features intricate patterns and national motifs, with the word “[COUNTRY]” written across the board in elegant golden calligraphy. All the chess pieces are off the board, arranged around it on the fabric — some lying on their side, others upright — as if waiting to be placed. Each piece is uniquely reimagined in shape, ornament, and texture, reflecting the architecture, cultural symbols, and color palette of [COUNTRY]. Rich materials, soft directional light, cinematic shadows, ultra-detailed editorial still life style, symmetrical top-down framing, 9:16 format.",
+        "一张高度逼真的传统棋盘垂直照片，从上方看，背景是受 [COUNTRY] 艺术遗产启发的纹理表面。棋盘上有复杂的图案和国家图案，棋盘上用优雅的金色书法写着“[COUNTRY]”字样。所有的棋子都离开了棋盘，围绕着棋盘排列在织物上——有些侧躺着，有些直立着——仿佛等待着被放置。每件作品在形状、装饰和质地上都经过独特的重新构想，反映了 [COUNTRY] 的建筑、文化符号和调色板。丰富的素材、柔和的定向光、电影般的阴影、超详细的编辑静物风格、对称的自上而下的取景、9：16 格式。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "photography"
+      ],
+      "coverImage": "images/145.png"
+    },
+    {
+      "id": 144,
+      "slug": "prompt-144",
+      "title": "梦幻般的蒸汽波失真",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1937027922679775432"
+      },
+      "images": [
+        "images/144.png",
+        "images/144-2.png"
+      ],
+      "prompts": [
+        "[SUBJECT] rendered in Dreamlike Vaporwave Distortion, with soft pastels and surreal effects. Employ a nostalgic color palette of [COLOR1] and [COLOR2] to evoke a sense of longing and ethereal beauty",
+        "[主题] 以梦幻般的蒸汽波失真渲染，带有柔和的粉彩和超现实效果。采用 [COLOR1] 和 [COLOR2] 的怀旧调色板，唤起渴望和空灵之美"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/144.png"
+    },
+    {
+      "id": 143,
+      "slug": "prompt-143",
+      "title": "迪士尼鸡尾酒",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1936726936409313294"
+      },
+      "images": [
+        "images/143.png",
+        "images/143-2.jpeg"
+      ],
+      "prompts": [
+        "A realistic, high-end cocktail in a frosted glass with a sparkling salt rim, filled with crystal-clear ice cubes. The drink is garnished with deep-blue kale leaves and delicate pastel-pink edible flowers. The lighting is moody and cinematic, with soft highlights on the glass. The entire visual style — color palette, lighting, background, and atmosphere — is inspired by the animated film 【MOVIE_TITLE】 by Disney, subtly reflecting its visual tone and mood. At the bottom of the image, in elegant golden serif text, it says: “Disney — 【MOVIE_TITLE】”. Vertical 9:16, ultra-detailed, photographic realism with artistic direction based on the film’s world.",
+        "一款逼真的高端鸡尾酒，装在磨砂玻璃杯中，带有波光粼粼的盐边，里面装满了晶莹剔透的冰块。这款饮料以深蓝色的羽衣甘蓝叶和精致的淡粉色食用花朵装饰。灯光是喜怒无常的和电影般的，玻璃上有柔和的亮点。整个视觉风格——调色板、灯光、背景和氛围——都受到了迪士尼动画电影【MOVIE_TITLE】的启发，巧妙地反映了它的视觉基调和情绪。在图片的底部，用优雅的金色衬线文字写着：“Disney — 【MOVIE_TITLE】”。垂直 9：16，超详细，摄影现实主义，艺术指导基于电影世界。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "food",
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/143.png"
+    },
+    {
+      "id": 142,
+      "slug": "prompt-142",
+      "title": "为任何品牌设计运动鞋",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1925139884920152110"
+      },
+      "images": [
+        "images/142.jpeg",
+        "images/142-2.jpeg"
+      ],
+      "prompts": [
+        "create image with 1:1 ratio   A branded footwear ad for [Brand], showcasing the high-end Brand shoe using brand technology and texture.(fiction a technology and texture based on brand DNA). The shoe is shown in dynamic floating perspective over a graph paper background layout with technical sketches and handwritten notes. A random lifestyle authentic photo featuring brand clothing in motion is taped in the corner, styled with street wear fashion. Emphasize the product's slogan with  bold typography. Layout features include product spec labels like Project a fiction brand title, Date, Size, and fiction model name in engineering style. The background reference with brand pantone color palettes with code number",
+        "以 1：1 的比例创建图片 [Brand] 的品牌鞋靴广告，使用品牌技术和纹理展示高端品牌鞋靴。（虚构一种基于品牌DNA的技术和质感）。这双鞋以动态浮动透视形式显示在方格纸背景布局上，并附有技术草图和手写注释。角落里贴着一张随机的生活方式真实照片，照片中展示了运动中的品牌服装，与街头服饰时尚相得益彰。用粗体排版强调产品的口号。布局功能包括产品规格标签，如工程样式的 Project a fiction brand title、Date、Size 和 fiction model name。带有品牌 pantone 调色板和代码编号的背景参考"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "fashion",
+        "paper-craft",
+        "photography",
+        "product",
+        "typography"
+      ],
+      "coverImage": "images/142.jpeg"
+    },
+    {
+      "id": 141,
+      "slug": "prompt-141",
+      "title": "监控级别的时尚洞察力",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1925431043122970869"
+      },
+      "images": [
+        "images/141.jpeg",
+        "images/141-2.jpeg"
+      ],
+      "prompts": [
+        "Create image with 1:1 ratio A cctv footage, \nA closed up view of focus woman carrying  [brand] [product] on street, a square zoomed window on the product, sci fi analyzing overlay UI with infos like brand name, date, time, location name, in brand color monospaced font, product name, width, height, weight, etc, vhs effect, glitch effect, film grainy",
+        "创建比例为 1：1 的图像闭路电视素材，\n焦点女性在街上抬着 [品牌] [产品] 的特写视图，产品上的方形缩放窗口，科幻分析叠加 UI，其中包含品牌名称、日期、时间、位置名称、品牌颜色等宽字体、产品名称、宽度、高度、粗细等信息、vhs 效果、毛刺效果、胶片颗粒感"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "product",
+        "sci-fi",
+        "typography",
+        "ui",
+        "vehicle"
+      ],
+      "coverImage": "images/141.jpeg"
+    },
+    {
+      "id": 140,
+      "slug": "prompt-140",
+      "title": "现代数字动漫风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1934970943769559430"
+      },
+      "images": [
+        "images/140.png",
+        "images/140-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a modern digital anime TV style. Use clean and sharp outlines, vivid and high-contrast colors, and digital cel shading with subtle gradients. Add visual effects like glows, particles, or light flares if appropriate. The character design should follow modern anime proportions, with detailed hair and expressive eyes. The background can be softly blurred or cinematic. The image should look like a frame from a high-quality anime series currently airing.",
+        "将此图像转换为现代数字动漫电视风格。使用干净锐利的轮廓、鲜艳和高对比度的颜色，以及具有微妙渐变的数字卡通底纹。添加视觉效果，如发光、粒子或光晕（如果合适）。角色设计应遵循现代动漫的比例，拥有细致的头发和富有表现力的眼睛。背景可以是柔和的模糊或电影般的。该图像应看起来像当前正在播出的高质量动漫系列中的帧。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character"
+      ],
+      "coverImage": "images/140.png"
+    },
+    {
+      "id": 139,
+      "slug": "prompt-139",
+      "title": "将您最喜欢的品牌变成生活方式产品",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1934631664153760241"
+      },
+      "images": [
+        "images/139.jpeg",
+        "images/139-2.jpeg"
+      ],
+      "prompts": [
+        "A high-quality studio product photo of a [brand name]-branded [product type], [floating / standing] against a solid background in the brand’s signature color. The product features the brand logo prominently and uses the official brand color palette. Clean composition, soft shadows, ultra-realistic materials and textures, no text, no props, professional commercial lighting, sharp focus, minimalist aesthetic.",
+        "一张高质量的工作室商品照片，其中包含 [品牌名称] 品牌 [商品类型]、[浮动/直立] 和纯色背景，采用品牌标志性的颜色。该商品突出品牌徽标，并使用官方品牌调色板。干净的构图，柔和的阴影，超逼真的材质和纹理，无文字，无道具，专业的商业照明，锐利的焦点，极简的美学。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "logo",
+        "minimalist",
+        "nature",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/139.jpeg"
+    },
+    {
+      "id": 138,
+      "slug": "prompt-138",
+      "title": "Gumroad样式图标",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1934745654888124753"
+      },
+      "images": [
+        "images/138.jpeg",
+        "images/138-2.jpeg"
+      ],
+      "prompts": [
+        "Create a high-resolution illustration of a [OBJECT] icon in the style of a flat, outlined sticker graphic. The icon should be made entirely from very thin, solid black outlines with no interior fill. Add a bold, soft-edged sticker-style contour around the icon using a flat, vibrant [YELLOW, BLUE, OR PINK] color. The result should look like a cartoon-style icon cut from black paper, outlined by a bright color. Do not use any white or filled shapes inside. No gradients, no shadows, no textures. Vector-friendly. Black background. Square aspect ratio.",
+        "以平面轮廓贴纸图形的样式创建 [OBJECT] 图标的高分辨率插图。图标应完全由非常细的纯黑色轮廓制成，没有内部填充。使用平坦、充满活力的 [黄色、蓝色或粉红色] 在图标周围添加大胆、边缘柔和的贴纸式轮廓。结果应看起来像从黑纸上剪下来的卡通风格图标，由鲜艳的颜色勾勒出来。不要在里面使用任何白色或填充的形状。没有渐变，没有阴影，没有纹理。对矢量友好。黑色背景。方形纵横比。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "illustration",
+        "interior",
+        "paper-craft",
+        "vehicle"
+      ],
+      "coverImage": "images/138.jpeg"
+    },
+    {
+      "id": 137,
+      "slug": "prompt-137",
+      "title": "透视一切",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1934528170264572227"
+      },
+      "images": [
+        "images/137.jpeg",
+        "images/137-2.jpeg"
+      ],
+      "prompts": [
+        "a fully transparent [product] made of ultra-clear iridescent glass, showing all internal components in photorealistic detail. The outer shell is glossy, refracts subtle rainbow colors, and reveals the product’s structure and mechanics. Scene lit with high-Kelvin studio lighting (~7000K) on a neutral background. The product maintains its real proportions, materials, and branding.",
+        "由超透明虹彩玻璃制成的完全透明 [产品]，以逼真的细节展示所有内部组件。外壳有光泽，折射出微妙的彩虹色，并揭示产品的结构和机械。在中性背景上使用高开尔文工作室照明 （~7000K） 照亮的场景。该产品保持其真实的比例、材料和品牌。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/137.jpeg"
+    },
+    {
+      "id": 136,
+      "slug": "prompt-136",
+      "title": "日常用品有皮肤",
+      "source": {
+        "name": "@Kerroudjm",
+        "url": "https://x.com/Kerroudjm/status/1934682610632151500"
+      },
+      "images": [
+        "images/136.png",
+        "images/136-2.jpeg"
+      ],
+      "prompts": [
+        "A high-quality studio photograph of a [OBJECT] fully covered in ultra-realistic [ANIMAL] texture (e.g., fur, feathers, skin, or scales), placed against a soft neutral background. The object’s original form remains visible but is wrapped in the animal’s natural pattern and surface detail. The image features clean composition, soft shadows, sharp focus, minimalist styling, professional lighting, and highly detailed textures—each hair, feather, or wrinkle should be visible. Format 1:1.",
+        "一张 [OBJECT] 的高质量工作室照片，完全覆盖在超逼真的 [ANIMAL] 纹理（例如，毛皮、羽毛、皮肤或鳞片）中，置于柔和的中性背景上。对象的原始形状仍然可见，但包裹在动物的自然图案和表面细节中。该图像具有干净的构图、柔和的阴影、清晰的焦点、极简主义的造型、专业的照明和高度详细的纹理——每根头发、羽毛或皱纹都应该可见。格式 1：1。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "minimalist",
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/136.png"
+    },
+    {
+      "id": 135,
+      "slug": "prompt-135",
+      "title": "棱柱形玻璃图标",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1934330176113938606"
+      },
+      "images": [
+        "images/135.jpeg",
+        "images/135-2.jpeg"
+      ],
+      "prompts": [
+        "Create a high-resolution illustration of a [skull] icon in the style of a glossy, translucent sculpture. The icon should appear as if made of curved, flowing glass with reflective surfaces. Infuse the form with vivid, refracted rainbow gradients that shift smoothly across its contours. The shape should be abstract yet recognizable, with a sleek, high-gloss finish and soft reflections that mimic light bending through clear material. Center the icon on a solid black background. No shadows, textures, or extra elements. Square aspect ratio.",
+        "以光泽、半透明雕塑的风格创建 [骷髅头] 图标的高分辨率插图。图标应看起来像是由具有反射表面的弯曲、流动的玻璃制成的。为形式注入生动的折射彩虹渐变，在其轮廓上平滑移动。形状应该是抽象的但可识别的，具有时尚、高光泽的饰面和柔和的反射，模仿光线穿过透明材料的弯曲。将图标置于纯黑色背景上居中。没有阴影、纹理或额外元素。方形纵横比。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "sculpture"
+      ],
+      "coverImage": "images/135.jpeg"
+    },
+    {
+      "id": 134,
+      "slug": "prompt-134",
+      "title": "生成真实电影海报",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1934339212561555949"
+      },
+      "images": [
+        "images/134.jpeg",
+        "images/134-2.jpeg",
+        "images/134-3.jpeg",
+        "images/134-4.jpeg"
+      ],
+      "prompts": [
+        "“[MOVIE TITLE ]” — cinematic movie poster design in ultra-realistic, high-definition style. Capture a dramatic and emotionally charged scene based on the film’s title. Use a high Kelvin color temperature to eliminate yellow tint, favoring cold, bluish tones or neutral whites. Add volumetric fog, sharp shadows, and deep depth of field. Simulate a cinematic lens with soft bloom, subtle lens flare, and film grain.\n\nRender the title “[MOVIE TITLE ]” in expressive kinetic typography that visually embodies the meaning of the word (e.g. dissolving, cracked, melting, glowing). Typography should feel integrated into the environment, bold and iconic.\n\nInclude a short, emotionally resonant tagline beneath the title. Overall composition must resemble a high-budget blockbuster movie poster, with a 2.35:1 aspect ratio and strong visual storytelling.",
+        "“[MOVIE NAME ]” — 超逼真、高清风格的电影海报设计。根据电影的标题捕捉一个充满戏剧性和情感的场景。使用高开尔文色温来消除黄色调，偏爱冷色调、蓝色调或中性白色。添加体积雾、锐利阴影和深景深。模拟具有柔和泛光、细微镜头光晕和胶片颗粒的电影镜头。\n\n以富有表现力的动态排版呈现标题“[MOVIE TITLE ]”，在视觉上体现单词的含义（例如，溶解、破裂、融化、发光）。排版应该感觉与环境融为一体，大胆而标志性。\n\n在标题下方包括一个简短的、能引起情感共鸣的标语。整体构图必须类似于高预算的大片电影海报，具有 2.35：1 的纵横比和强烈的视觉叙事性。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "landscape",
+        "logo",
+        "poster",
+        "typography"
+      ],
+      "coverImage": "images/134.jpeg"
+    },
+    {
+      "id": 133,
+      "slug": "prompt-133",
+      "title": "幽灵形态",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1934662213702140116"
+      },
+      "images": [
+        "images/133.png",
+        "images/133-2.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic photograph of a [SUBJECT] entirely made from a single, semi-rigid transparent material that drapes and folds like sheer plastic or molten glass. The object is fully recognizable in shape, yet ghostly and fluid, as if sculpted from air and frozen in motion. Set in a moody, industrial interior with aged concrete walls and diffused daylight from metal-barred windows. The lighting gently highlights the reflections, edges, and flowing curves of the transparent form. Dreamlike, minimalist, surreal design aesthetic.",
+        "一张 [SUBJECT] 的超写实照片，完全由单一的、半刚性的透明材料制成，像纯粹的塑料或熔融玻璃一样悬垂和折叠。这个物体的形状是完全可识别的，但又幽灵般流动，仿佛从空气中雕刻出来，在运动中冻结。坐落在喜怒无常的工业室内，拥有老化的混凝土墙和从金属栅栏窗户射出的日光。灯光柔和地突出了透明形式的反射、边缘和流动曲线。梦幻般的、极简主义的、超现实主义的设计美学。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "minimalist",
+        "photography"
+      ],
+      "coverImage": "images/133.png"
+    },
+    {
+      "id": 132,
+      "slug": "prompt-132",
+      "title": "悬浮魔幻现实主义",
+      "source": {
+        "name": "@BeanieBlossom",
+        "url": "https://x.com/BeanieBlossom/status/1934581820433301996"
+      },
+      "images": [
+        "images/132.jpeg",
+        "images/132-2.jpeg"
+      ],
+      "prompts": [
+        "An old-fashioned postal shack floating on a space rock, with envelopes fluttering like wings and planets lined up as waiting customers - humorous, magical realism.",
+        "一个漂浮在太空岩石上的老式邮政小屋，信封像翅膀一样飘动，行星排成一排等待的顾客 - 幽默、魔幻现实主义。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "fashion"
+      ],
+      "coverImage": "images/132.jpeg"
+    },
+    {
+      "id": 131,
+      "slug": "prompt-131",
+      "title": "自定义毛绒钥匙扣",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1934973851164897444"
+      },
+      "images": [
+        "images/131.jpeg",
+        "images/131-2.jpeg"
+      ],
+      "prompts": [
+        "Close-up photo of a small plush keychain of [attached image/emojis]  held gently between two fingers, made of soft felt or fuzzy material, cartoon-style proportions, embroidered face with simple expressive features, character designed to resemble, attached to a shiny silver keyring, neutral beige background, shallow depth of field, soft natural lighting, highly detailed texture, cute and handcrafted aesthetic, studio photography, 1:1 aspect ratio",
+        "[附图/表情符号] 的小毛绒钥匙扣的特写照片，用两根手指轻轻握住，由柔软的毛毡或毛茸茸的材料制成，卡通风格的比例，具有简单表现特征的刺绣脸，设计相似的人物，附在闪亮的银色钥匙圈上，中性米色背景，浅景深，柔和的自然光，高度详细的纹理，可爱和手工制作的美感， 摄影棚摄影，1：1 纵横比"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "emoji",
+        "felt",
+        "nature",
+        "photography",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/131.jpeg"
+    },
+    {
+      "id": 130,
+      "slug": "prompt-130",
+      "title": "创建超现实不可能的图像",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1934903456596451734"
+      },
+      "images": [
+        "images/130.jpeg",
+        "images/130-2.jpeg"
+      ],
+      "prompts": [
+        "Create a surreal split-scene where the left half is an underwater version of a [SCENE], filled with marine life (fish, sharks, octopus, coral, bubbles), and the right half is the regular dry version of the same [SCENE] continuing naturally. Separate the two halves with a vertical wall of water held by a magical force, as if the ocean is cut in half. The scene should align across both sides, maintaining realism while showcasing the impossible scenario. Emphasize lighting and reflection differences between water and air environments.",
+        "创建一个超现实的分割场景，其中左半部分是 [SCENE] 的水下版本，充满了海洋生物（鱼、鲨鱼、章鱼、珊瑚、气泡），右半部分是同一 [SCENE] 的常规干燥版本自然延续。用一道由神奇力量支撑的垂直水墙将两半分开，仿佛海洋被切成两半。场景应在两侧对齐，在展示不可能的场景的同时保持真实感。强调水和空气环境之间的光照和反射差异。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "landscape",
+        "nature"
+      ],
+      "coverImage": "images/130.jpeg"
+    },
+    {
+      "id": 129,
+      "slug": "prompt-129",
+      "title": "创建悬浮切片水果",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1934562439326306814"
+      },
+      "images": [
+        "images/129.jpeg",
+        "images/129-2.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic photograph of a [FRUIT] sliced into five glossy layers, each slice floating vertically in mid-air with glistening juice droplets at the edges. The slices cast soft, natural shadows on each other. The [FRUIT] has a vibrant skin with appropriate interior details .Set against a softly blurred tropical garden background with hints of lush green leaves and dappled sunlight, the scene is lit with warm, directional golden-hour lighting, enhancing the vivid colors and depth",
+        "一张 [FRUIT] 的超写实照片，被切成五个光滑的层，每个切片垂直漂浮在半空中，边缘有闪闪发光的汁液滴。切片彼此之间投射柔和、自然的阴影。[FRUIT] 拥有充满活力的皮肤和适当的内部细节。在柔和模糊的热带花园背景下，郁郁葱葱的绿叶和斑驳的阳光，场景由温暖、定向的金色小时照明照亮，增强了鲜艳的色彩和深度"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "landscape",
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/129.jpeg"
+    },
+    {
+      "id": 128,
+      "slug": "prompt-128",
+      "title": "一个字的无限反射",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1934670309942018397"
+      },
+      "images": [
+        "images/128.png",
+        "images/128-2.jpeg"
+      ],
+      "prompts": [
+        "A [PERSON] in a dark room with a glowing projection of the word “[WORD]” repeated endlessly across the walls and body. The text is projected in high-contrast, neon [COLOR], wrapping around the contours of the object, creating a surreal, futuristic lighting effect. The background and object are seamlessly blended into the immersive text environment. Photorealistic, sharp shadows and light distortion where the text bends over curves. Studio lighting with deep contrast, moody cyberpunk aesthetic.",
+        "一个 [PERSON] 在一个黑暗的房间里，“[WORD]”这个词的发光投影在墙壁和身体上无休止地重复。文本以高对比度的霓虹灯 [COLOR] 投影，包裹在对象的轮廓周围，营造出超现实的未来主义照明效果。背景和对象无缝混合到沉浸式文本环境中。照片级真实感、锐利的阴影和文本在曲线上弯曲的光线扭曲。具有深对比度、喜怒无常的赛博朋克美学的工作室照明。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "interior",
+        "landscape",
+        "neon",
+        "photography",
+        "sci-fi"
+      ],
+      "coverImage": "images/128.png"
+    },
+    {
+      "id": 127,
+      "slug": "prompt-127",
+      "title": "符号冲突",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1934527984578535561"
+      },
+      "images": [
+        "images/127.png",
+        "images/127-2.jpeg"
+      ],
+      "prompts": [
+        "A surreal yet hyper-realistic image in levitation photography style, where elements of [subject] float chaotically and randomly above an outstretched hand, interwoven with symbolic elements that directly oppose it.\n\nThe background forms dynamically to visually embody the symbolism of the subject and its opposite, through blurred or abstract details that reflect either tension or harmony between the two—like a mirror inside a dream.\n\nEach element floats at a unique angle and varying distance.\n\nBackground: Shifts according to the subject and its opposite\n\nLighting: Soft cinematic with dreamy shadows\n\nStyle: Hyper-realistic + Levitation Photography + Fantasy\n\nAspect Ratio: 1:1",
+        "悬浮摄影风格的超现实而超现实的图像，其中 [主体] 的元素混乱而随机地漂浮在伸出的手上方，与直接对立的象征性元素交织在一起。\n\n背景动态形成，通过模糊或抽象的细节在视觉上体现主题及其对立面的象征意义，这些细节反映了两者之间的张力或和谐——就像梦中的镜子。\n\n每个元素都以独特的角度和不同的距离漂浮。\n\n背景：根据主体及其对立面而变化\n\n照明：柔和的电影感，带有梦幻般的阴影\n\n风格：超写实 + 悬浮摄影 + 奇幻\n\n长宽比：1：1"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "fantasy",
+        "photography"
+      ],
+      "coverImage": "images/127.png"
+    },
+    {
+      "id": 126,
+      "slug": "prompt-126",
+      "title": "重新构想的超现实主义广告",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1934702903932957023"
+      },
+      "images": [
+        "images/126.jpeg",
+        "images/126-2.jpeg"
+      ],
+      "prompts": [
+        "“[Product Name]” placed at the center in full photorealism, surrounded by surreal vector illustrations using exactly two bold, vibrant colors that match the product’s mood.\nThe scene is minimalistic yet energetic, with abstract vector shapes (symbols, lines, expressions, etc.) orbiting or interacting with the product.\nAdd the real logo clearly and integrate a short 3–4 word slogan at the bottom.\nStyle: surreal, high-resolution, minimal, cinematic lighting, 1:1 aspect ratio.",
+        "“[产品名称]”以完全逼真的方式放置在中心，周围环绕着超现实主义的矢量插图，使用两种大胆、鲜艳的颜色，与产品的情绪相匹配。\n场景简约而充满活力，抽象的矢量形状（符号、线条、表情等）围绕产品运行或与产品交互。\n清楚地添加真实的 logo，并在底部加入一个 3-4 字的简短标语。\n风格：超现实、高分辨率、极简、电影般的照明、1：1 纵横比。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "landscape",
+        "minimalist",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/126.jpeg"
+    },
+    {
+      "id": 125,
+      "slug": "prompt-125",
+      "title": "时尚品牌娃娃",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1934688112741085562"
+      },
+      "images": [
+        "images/125.png",
+        "images/125-2.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic photograph of a fashion doll styled in the aesthetic of [BRAND], sitting on a plush, cream-colored bed with soft folds. The doll’s look reflects the brand’s signature elements — from hair and outfit to accessories — arranged thoughtfully to evoke a dreamy, vintage-inspired editorial. Studio-lit with warm, diffused lighting and a creamy, ivory-toned palette, the scene emulates luxury fashion photography with a soft, dollhouse-like atmosphere and shallow depth of field.",
+        "一张超写实的照片，一个时尚娃娃以 [BRAND] 的美学风格，坐在一张带有柔软褶皱的奶油色毛绒床上。这款玩偶的外观反映了该品牌的标志性元素——从头发和服装到配饰——经过精心安排，让人联想到梦幻般的复古风格社论。工作室照明采用温暖的漫射灯光和奶油色的象牙色调调色板，该场景以柔和的玩具屋般的氛围和浅景深模拟奢华时尚摄影。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "fashion",
+        "landscape",
+        "logo",
+        "nature",
+        "photography",
+        "retro",
+        "toy"
+      ],
+      "coverImage": "images/125.png"
+    },
+    {
+      "id": 124,
+      "slug": "prompt-124",
+      "title": "磨砂模糊剪影",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1934249977326289141"
+      },
+      "images": [
+        "images/124.jpeg",
+        "images/124-2.jpeg"
+      ],
+      "prompts": [
+        "A black and white photograph shows the blurred silhouette of a [SUBJECT] behind a frosted or translucent surface. The [PART] is sharply defined and pressed against the surface, creating a stark contrast with the rest of the hazy, indistinct figure. The background is a soft gradient of gray tones, enhancing the mysterious and artistic atmosphere",
+        "一张黑白照片显示了磨砂或半透明表面后面 [SUBJECT] 的模糊剪影。[PART] 轮廓分明，压在表面，与朦胧、模糊的人物的其余部分形成鲜明对比。背景是灰色调的柔和渐变，增强了神秘和艺术的氛围"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "photography",
+        "portrait"
+      ],
+      "coverImage": "images/124.jpeg"
+    },
+    {
+      "id": 123,
+      "slug": "prompt-123",
+      "title": "植物雕塑",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1934566157736083614"
+      },
+      "images": [
+        "images/123.png",
+        "images/123-2.jpeg"
+      ],
+      "prompts": [
+        "The [subject] appears as if organically grown from intertwining plants, flowers, and vines. Leaf-like textures and blooming forms fuse seamlessly with anatomical or structural details, creating a surreal hybrid of nature and design. The composition feels ethereal, with natural asymmetry and dreamlike flow.",
+        "[主题] 看起来就像是从交织在一起的植物、花朵和藤蔓中有机生长出来的。叶子般的纹理和盛开的形式与解剖学或结构细节无缝融合，创造出自然与设计的超现实混合体。构图感觉空灵，具有自然的不对称和梦幻般的流动。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "nature",
+        "sculpture"
+      ],
+      "coverImage": "images/123.png"
+    },
+    {
+      "id": 122,
+      "slug": "prompt-122",
+      "title": "史莱姆制成的玩具运输车",
+      "source": {
+        "name": "@miilesus",
+        "url": "https://x.com/miilesus/status/1934593675276796090"
+      },
+      "images": [
+        "images/122.png",
+        "images/122-2.jpeg"
+      ],
+      "prompts": [
+        "{\n  \"style\": \"Realistic 3D render\",\n  \"material\": \"Glossy slime-like material\",\n  \"texture\": [\"smooth\", \"soft\", \"stretchy\", \"shiny\"],\n  \"color\": \"VARIABLE\",  \n  \"object_type\": \"VARIABLE\",  \n  \"background\": \"plain white\",\n  \"lighting\": \"soft studio lighting\",\n  \"details\": {\n    \"focus\": \"single object centered\",\n    \"shadows\": \"soft and subtle\",\n    \"reflection\": \"light highlights on surface\",\n    \"depth\": \"shallow depth of field\"\n  },\n  \"format\": \"close-up or three-quarter view\",\n  \"mood\": \"playful, clean, toy-like\",\n  \"prompt_template\": \"A {color} {object_type} made of glossy slime material, soft and stretchy texture, realistic 3D look, set against a plain white background, soft lighting and smooth highlights\"\n}",
+        "{\n“style”： “逼真的 3D 渲染”，\n“material”： “有光泽的粘液状材质”，\n“texture”： [“光滑”， “柔软”， “弹性”， “闪亮”]，\n“color”： “变量”，\n“object_type”： “变量”，\n“background”： “纯白色”，\n“lighting”： “柔和的工作室照明”，\n“详细信息”： {\n“focus”： “以单个对象为中心”，\n“shadows”： “柔和而微妙”，\n“reflection”： “表面上的光高光”，\n“depth”： “浅景深”\n},\n“format”： “特写或四分之三视图”，\n“mood”： “俏皮的、干净的、玩具般的”，\n“prompt_template”： “由有光泽的粘液材料制成的 {color} {object_type}，质地柔软有弹性，逼真的 3D 外观，以纯白色背景为背景，光线柔和，高光平滑”\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/122.png"
+    },
+    {
+      "id": 121,
+      "slug": "prompt-121",
+      "title": "文艺复兴时期的解剖学研究",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1934928547971559565"
+      },
+      "images": [
+        "images/121.png",
+        "images/121-2.jpeg"
+      ],
+      "prompts": [
+        "A Renaissance anatomical study of a [subject], meticulously illustrated in fine graphite and ink cross-hatching, with transparent tissue overlays revealing skeletal and muscular systems. Labeled in elegant Latin calligraphy and presented on aged parchment, the composition exudes scholarly precision and classical beauty.",
+        "文艺复兴时期对 [主题]的解剖学研究，用精细的石墨和墨水交叉影线精心说明，透明的组织覆盖层露出骨骼和肌肉系统。该作品以优雅的拉丁书法标记，并呈现在古老的羊皮纸上，散发着学术的精确和古典之美。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "paper-craft"
+      ],
+      "coverImage": "images/121.png"
+    },
+    {
+      "id": 120,
+      "slug": "prompt-120",
+      "title": "奇趣风格3D乙烯基玩具",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1931668551531929630"
+      },
+      "images": [
+        "images/120.png",
+        "images/120-2.jpeg"
+      ],
+      "prompts": [
+        "Chibi-style 3D vinyl toy of [subject], rendered in [color1] and [color2] tones, front-facing on a white background. Minimalist composition with soft shadows, oversized head and tiny body proportions, clean OC renderer output in Cinema 4D. Toy-like shine and playful charm.",
+        "[主体]的奇趣风格 3D 乙烯基玩具，以[颜色 1]和[颜色 2]色调呈现，正面朝向白色背景。极简主义构图，带有柔和的阴影，头部巨大而身体比例缩小，Cinema 4D 中的干净 OC 渲染输出。玩具般的光泽和充满趣味的魅力。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "minimalist",
+        "toy"
+      ],
+      "coverImage": "images/120.png"
+    },
+    {
+      "id": 119,
+      "slug": "prompt-119",
+      "title": "城市绣花贴纸照片",
+      "source": {
+        "name": "@Kerroudjm",
+        "url": "https://x.com/Kerroudjm/status/1931040962513379672"
+      },
+      "images": [
+        "images/119.png",
+        "images/119-2.jpeg"
+      ],
+      "prompts": [
+        "Create a close-up, square-format (1:1) photo of an embroidered patch inspired by the uploaded image. The design should feature a clean, cartoon-style embroidered interpretation of the original subject with rich thread texture and vibrant colors. The shape of the patch can vary (round, oval, shielded, silhouette-based), but the output image must remain square.\nIntegrate the national colors of the country represented—such as in the text, the border, or small decorative accents—drawing inspiration from the flag to enhance local identity. Add embroidered capital-letter text like the name of the city or country, either curved or straight. Use a soft off-white fabric background and natural lighting to bring out texture and depth.",
+        "创建一个近景、正方形格式（1:1）的绣花贴片照片，以上传的图片为灵感。设计应采用干净的卡通风格刺绣诠释原图主题，具有丰富的线紡纹理和鲜艳的颜色。贴片的形状可以变化（圆形、椭圆形、盾形、轮廓形），但输出图片必须保持正方形。\n融入所代表国家的国色——如文本、边框或小装饰细节中，从国旗中汲取灵感，增强地方身份。添加刺绣的大写字母文字，如城市或国家的名字，可以是曲线或直线。使用柔和的米白色背景布料和自然光线，以突出纹理和深度。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "nature",
+        "paper-craft",
+        "photography",
+        "vehicle"
+      ],
+      "coverImage": "images/119.png"
+    },
+    {
+      "id": 118,
+      "slug": "prompt-118",
+      "title": "品牌产品数字广告",
+      "source": {
+        "name": "@shushant_l",
+        "url": "https://x.com/shushant_l/status/1931316125029339572"
+      },
+      "images": [
+        "images/118.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic, ultra-detailed 3D digital advertisement showcasing a Pepsi can bursting open at its center, sending a refreshing splash of carbonated cola into the air, with effervescent bubbles and ice cubes flying outward. The can’s metallic surface is rendered with sharp, photorealistic textures, complete with condensation droplets, light reflections, and subtle scratches. Surrounding the scene are cold, translucent ice shards and a twist of lemon zest caught mid-motion, adding a vibrant contrast. The background features a deep electric blue gradient with cinematic volumetric lighting and soft lens flares. Green mint leaves and misty vapors add a refreshing, natural accent. The entire scene is rendered in 4K UHD using advanced global illumination, HDR lighting, and realistic shadows. The composition evokes premium beverage advertising with a dramatic tone, created using tools like Unreal Engine + Octane Render for maximum visual impact.",
+        "一个超现实的、超详细的 3D 数字广告，展示百事罐在中心爆裂，喷出清凉的碳酸可乐，气泡和冰块飞溅。罐子的金属表面具有锐利的、写实的纹理，包括冷凝水滴、光线反射和细微的划痕。场景周围是冷的透明冰片和柠檬皮在空中飞舞，增添了鲜明的对比。背景是深电光渐变，带有电影级体积照明和柔和的镜头光晕。绿色薄荷叶和雾气增添了清凉的自然点缀。整个场景使用高级全局光照、HDR 照明和真实的阴影在 4K UHD 下渲染。构图以高端饮料广告的戏剧性基调呈现，使用 Unreal Engine + Octane Render 等工具以达到最大的视觉冲击力。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "nature",
+        "photography",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/118.jpeg"
+    },
+    {
+      "id": 117,
+      "slug": "prompt-117",
+      "title": "动漫机甲风格化机械设计图",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1931711452160651654"
+      },
+      "images": [
+        "images/117.png",
+        "images/117-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a stylized mechanical design sheet inspired by Japanese anime mecha blueprints.\nRender the subject with precise, clean linework and semi-realistic cel-shading, as if it were a technical illustration from an anime artbook.\nBreak down the design into parts (e.g. head, hand, accessory, full body) and arrange them like a reference sheet, with different angles and views.\nInclude soft handwritten notes or Japanese characters scattered like concept annotations.\nUse muted digital colors (red, gray, metallic tones) and draw the background in a loose watercolor anime landscape style — cliffs, cityscapes, or grassland ruins.\nThe final composition should feel like an official design page for an animated sci-fi series or manga.\nKeep the format horizontal, like a blueprint or character sheet, with a balance between precision and artistic flair."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "character",
+        "futuristic",
+        "illustration",
+        "landscape",
+        "sci-fi"
+      ],
+      "coverImage": "images/117.png"
+    },
+    {
+      "id": 116,
+      "slug": "prompt-116",
+      "title": "任天堂风格的3D卡通插画",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1931647658382258183"
+      },
+      "images": [
+        "images/116.png",
+        "images/116-2.jpeg"
+      ],
+      "prompts": [
+        "Transform this image into a Nintendo-inspired 3D cartoon style illustration.\n\nUse soft, rounded 3D shapes and clean, toy-like geometry to give the characters and objects a charming, handcrafted look.\n\nCharacters should have exaggerated, childlike proportions (large heads, small limbs), with expressive, simplified faces and bright, colorful clothing — similar to designs seen in Zelda: Link’s Awakening, Animal Crossing, or Miitopia.\n\nApply smooth, matte textures with no realistic detail — everything should look cheerful and slightly plastic, as if sculpted from soft clay or digital vinyl.\n\nThe environment should be bright and whimsical, with stylized grass, puffy clouds, geometric trees, and soft lighting like a sunny afternoon.\n\nThe overall tone should be lighthearted, clean, and family-friendly, like a frame from a Nintendo fantasy adventure game."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "cartoon",
+        "character",
+        "clay",
+        "fantasy",
+        "gaming",
+        "illustration",
+        "landscape",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/116.png"
+    },
+    {
+      "id": 115,
+      "slug": "prompt-115",
+      "title": "冰爽优雅的产品海报",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1931371954524545120"
+      },
+      "images": [
+        "images/115.png",
+        "images/115-2.jpeg"
+      ],
+      "prompts": [
+        "Imagine a visual concept where [insert your product] — featuring Korean text on the label — is suspended inside a cracked, ultra-clear block of ice. The product is fully visible through the ice, with soft frost forming around it. It rests on smooth white silk, and the ambient lighting is cold and elegant, with reflections dancing across the surface. Describe the entire scene in rich visual detail, in the style of a luxurious Korean skincare advertisement."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "poster",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/115.png"
+    },
+    {
+      "id": 114,
+      "slug": "prompt-114",
+      "title": "Monochrome LCD 效果",
+      "source": {
+        "name": "@hckmstrrahul",
+        "url": "https://x.com/hckmstrrahul/status/1931412135277678837"
+      },
+      "images": [
+        "images/114.png",
+        "images/114-2.jpeg"
+      ],
+      "prompts": [
+        "{\n  \"styleAesthetic\": {\n    \"title\": \"Monochrome Pixel Mosaic\",\n    \"overallVibe\": \"Retro mobile-screen pixel art—clean, minimal, and slightly nostalgic\",\n    \"renderingStyle\": \"1-bit square-pixel grid with optional dithering to suggest tone and depth\",\n    \"viewAngle\": \"Orthographic front view (no perspective distortion)\",\n    \"pixelation\": {\n      \"pixelSize\": 6,                     // width/height of each square in px (tweak per output res)\n      \"pixelShape\": \"perfect square\",\n      \"gridAlignment\": \"uniform, no gaps\",\n      \"ditheringPattern\": \"Floyd–Steinberg or ordered 2×2\"\n    },\n    \"colorPalette\": {\n      \"pixelColor\": \"#000000\",            // foreground pixels\n      \"backgroundColor\": \"#8CA17C\",       // muted pastel green sample; replace to recolor\n      \"paletteType\": \"1-bit monochrome\"\n    },\n    \"lightingAndShadows\": {\n      \"pixelDropShadow\": {\n        \"enabled\": true,\n        \"offsetX\": 0,\n        \"offsetY\": 1,\n        \"blur\": 2,\n        \"opacity\": 0.25\n      },\n    },\n    \"materialsAndTextures\": [\n      {\n        \"type\": \"Matte LCD surface\",\n        \"description\": \"Flat display with very fine grain/noise to simulate old LCD texture\",\n        \"noiseIntensity\": 0.01\n      }\n    ],\n    \"typography\": {\n      \"fontFamily\": \"monospaced bitmap\",\n      \"weight\": \"bold\",\n      \"capitalization\": \"uppercase\",\n      \"letterSpacing\": 0,\n      \"align\": \"center\"\n    },\n    \"postProcessing\": {\n      \"edgeSmoothing\": \"none (hard pixel edges preserved)\",\n      \"filmGrain\": 0.01,\n      \"overallContrast\": 1.0\n    },\n    \"adaptabilityHints\": {\n      \"applyToPhotographs\": \"posterize → 1-bit → downsample to pixel grid → apply dithering\",\n      \"applyToVectorText\": \"render glyphs to bitmap grid using same pixel size and drop shadow\",\n      \"safeResize\": \"always scale by whole-number multiples to keep squares crisp\"\n    }\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "minimalist",
+        "photography",
+        "pixel",
+        "poster",
+        "retro",
+        "typography"
+      ],
+      "coverImage": "images/114.png"
+    },
+    {
+      "id": 113,
+      "slug": "prompt-113",
+      "title": "发光图标",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1931350205649350935"
+      },
+      "images": [
+        "images/113.jpeg",
+        "images/113-2.jpeg"
+      ],
+      "prompts": [
+        "A close-up digital photo of a human hand gently holding a glowing neon blue square icon featuring the [LOGO NAME] logo, set against a smooth dark gradient background. The blue light from the icon softly illuminates the fingers, casting a futuristic glow. The background is minimal and blurred, emphasizing the icon and the hand. High detail, cinematic lighting, modern tech aesthetic."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "logo",
+        "minimalist",
+        "neon",
+        "photography"
+      ],
+      "coverImage": "images/113.jpeg"
+    },
+    {
+      "id": 112,
+      "slug": "prompt-112",
+      "title": "重点线条勾勒",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1931637370639520011"
+      },
+      "images": [
+        "images/112.jpeg",
+        "images/112-2.jpeg"
+      ],
+      "prompts": [
+        "A digital illustration of a [SUBJECT], portrayed with a network of glowing clean pristine blue lines outlining its anatomy. The image is set against a dark background, highlighting the [SUBJECT] form and features. A specific area such as [PART] is emphasized with a red glow to indicate a point of interest or significance. The style is both educational and visually captivating, designed to resemble an advanced imaging technique"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "illustration"
+      ],
+      "coverImage": "images/112.jpeg"
+    },
+    {
+      "id": 111,
+      "slug": "prompt-111",
+      "title": "3d 超写实场景模型",
+      "source": {
+        "name": "@PatriciaRed_",
+        "url": "https://x.com/PatriciaRed_/status/1931165199987278330"
+      },
+      "images": [
+        "images/111.jpeg",
+        "images/111-2.jpeg"
+      ],
+      "prompts": [
+        "3d hyperrealistic model-scenery of a long-haired woman wearing a flowing maxi dress walking up a curved staircase with an arched doorway at the end with a view to a tiny glowing moon, framed by lush climbing vines, setting over a round base made out of moss and tiny bioluminescent mushrooms, ethereal lighting, staging aesthetics, dark plain background --ar 4:5 --c 6 --s 100"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "interior",
+        "landscape"
+      ],
+      "coverImage": "images/111.jpeg"
+    },
+    {
+      "id": 110,
+      "slug": "prompt-110",
+      "title": "皮克斯风格角色表",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1931750584090066979"
+      },
+      "images": [
+        "images/110.png"
+      ],
+      "prompts": [
+        "A character sheet of [detailed description of thecharacter], in the style of Pixar, featuring multiple poses and expressions from different angles, including concept art, pencil sketches, a full-body reference sheet, and a white background. The sheet includes wide shots, low-angle views, 3D renders, and Octane renderings, highly detailed result."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "character"
+      ],
+      "coverImage": "images/110.png"
+    },
+    {
+      "id": 109,
+      "slug": "prompt-109",
+      "title": "涂料飞溅Logo",
+      "source": {
+        "name": "@nim_null",
+        "url": "https://x.com/nim_null/status/1928008305705664661"
+      },
+      "images": [
+        "images/109.png"
+      ],
+      "prompts": [
+        "make a hyper-realistic 3D render of the attached logo, formed by glossy liquid paint splashes. Paint sculpts the outline using the exact palette from the reference. Smooth, fluid high-gloss splashes catch highlights; logo floats on pure white."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "logo"
+      ],
+      "coverImage": "images/109.png"
+    },
+    {
+      "id": 108,
+      "slug": "prompt-108",
+      "title": "标志液化",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1931723259734888582"
+      },
+      "images": [
+        "images/108.jpeg",
+        "images/108-2.png"
+      ],
+      "prompts": [
+        "Create a photograph of a [BRAND] logo formed from four vibrant paint splashes: red, blue, green, and yellow, captured mid-motion. Each color flows dynamically across different parts of the logo, as if sculpted from liquid paint. Droplets are suspended in the air around it, enhancing the illusion of movement. Set against a dark background with soft, vivid lighting that accentuates the glossy texture and fluid motion\n\nUse appropriate colors for the logos."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "logo",
+        "photography"
+      ],
+      "coverImage": "images/108.jpeg"
+    },
+    {
+      "id": 107,
+      "slug": "prompt-107",
+      "title": "超级动物英雄",
+      "source": {
+        "name": "@Kerroudjm",
+        "url": "https://x.com/Kerroudjm/status/1931742320233230743"
+      },
+      "images": [
+        "images/107.png",
+        "images/107-2.jpeg"
+      ],
+      "prompts": [
+        "A hyper-realistic square 1:1 portrait of a [YOUR ANIMAL] standing in a heroic pose, facing slightly left. The animal wears a textured dark gray superhero suit, form-fitting and matte, with visible fabric grain and subtle seams.\n\nOn its chest, inside a golden metallic Superman-style diamond emblem, is a fabric-embroidered version of the [COUNTRY] national flag (realistic stitching, slightly raised).\n\nDraped over the animal’s shoulder is a flowing cape designed from the [COUNTRY] flag, with rich fabric folds and natural weight.\n\nBehind the subject, use a realistic fabric backdrop displaying the full [COUNTRY] flag, slightly out of focus to add depth, with soft shadows to enhance realism.\n\nLighting should be warm and directional (studio-style), emphasizing the animal’s fur texture, suit material, and the contours of a subtly muscular chest. The overall tone is dramatic and cinematic, with a warm color grading and no excessive contrast. The head must be fully visible — no cropping."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "portrait"
+      ],
+      "coverImage": "images/107.png"
+    },
+    {
+      "id": 106,
+      "slug": "prompt-106",
+      "title": "时间之神",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1931726518952034462"
+      },
+      "images": [
+        "images/106.png",
+        "images/106-2.jpeg"
+      ],
+      "prompts": [
+        "Colossal marble statue of [INSERT OBJECT OR CHARACTER HERE], wings (if applicable) spread in divine majesty, adorned with ornate golden armor and flowing baroque robes, cracked marble textures with soft patina, glowing sacred emblem on chest, standing within a celestial golden dome, surrounded by divine architecture, dramatic god rays from above, dynamic mid-action pose, ultra-detailed renaissance sculpture style, cinematic lighting, majestic and sacred atmosphere, 8k resolution"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "character",
+        "sculpture"
+      ],
+      "coverImage": "images/106.png"
+    },
+    {
+      "id": 105,
+      "slug": "prompt-105",
+      "title": "刺绣logo",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1931713849067241960"
+      },
+      "images": [
+        "images/105.jpeg"
+      ],
+      "prompts": [
+        "A hyperrealistic embroidered textile artwork of the [SUBJECT], created with colored thread and soft fabric textures. The design features dense, tactile stitching and raised embroidery that mimics the actual form and branding. Set against a plain, off-white fabric background, with clean studio lighting and a sharp close-up view. Emphasize threadwork, texture, and handmade imperfections for a realistic soft sculpture look."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "sculpture"
+      ],
+      "coverImage": "images/105.jpeg"
+    },
+    {
+      "id": 104,
+      "slug": "prompt-104",
+      "title": "珐琅马赛克瓷砖风格",
+      "source": {
+        "name": "@mariia_gonchar",
+        "url": "https://x.com/mariia_gonchar/status/1931774946608370013"
+      },
+      "images": [
+        "images/104.png"
+      ],
+      "prompts": [
+        "Visualize any selected emoji [] as an ultra-detailed, hyper-realistic 3D sculpture fully composed of luxurious enamel mosaic tiles. The emoji should retain its iconic silhouette and proportions, reinterpreted as a stylized 3D figure made entirely from curved, faceted, and geometrically interlocked enamel tiles in a radiant mosaic pattern.\n> Use high-gloss enamel tiles in varied shades derived from the emoji’s symbolic palette—integrating metallic accents, opalescent glazes, deep ceramic pigmentation, and subtle iridescence. Tile surfaces must exhibit gentle bevels, crisp joints, and tactile depth to emulate elite architectural mosaic work.\n> Ensure no visible support structures—the figure must appear freestanding and weightless, suspended mid-air at the exact center of the frame.\n> Background: pure white studio environment with soft ambient shadows directly beneath the sculpture to emphasize spatial presence and floating realism.\n> Lighting: cinematic, diffused from multiple angles to"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "emoji",
+        "landscape",
+        "sculpture"
+      ],
+      "coverImage": "images/104.png"
+    },
+    {
+      "id": 103,
+      "slug": "prompt-103",
+      "title": "刺绣风格",
+      "source": {
+        "name": "@firatbilal",
+        "url": "https://x.com/firatbilal/status/1931762571876446256"
+      },
+      "images": [
+        "images/103.png"
+      ],
+      "prompts": [
+        "{\n  \"title\": \"Adaptive Embroidered Brooch Prompt Generator\",\n  \"version\": \"2.0\",\n  \"description\": \"Generate a prompt for an embroidered brooch based on text description or uploaded image.\",\n  \"inputs\": {\n    \"reference_mode\": {\n      \"type\": \"select\",\n      \"label\": \"Reference Source\",\n      \"options\": [\"describe manually\", \"use uploaded image\", \"combine both\"],\n      \"default\": \"describe manually\"\n    },\n    \"theme_text\": {\n      \"type\": \"text\",\n      \"label\": \"Describe the Theme or Motif\",\n      \"placeholder\": \"e.g. an owl in a forest, biomechanical skull, dancing figures\"\n    },\n    \"image_reference_description\": {\n      \"type\": \"text\",\n      \"label\": \"Describe what's in the uploaded image (if using image mode)\",\n      \"placeholder\": \"e.g. a mechanical skull with succulents growing from it\"\n    },\n    \"shape\": {\n      \"type\": \"select\",\n      \"label\": \"Brooch Shape\",\n      \"options\": [\"circular\", \"oval\", \"square\", \"irregular\"],\n      \"default\": \"oval\"\n    },\n    \"style\": {\n      \"type\": \"select\",\n      \"label\": \"Embroidery Style\",\n      \"options\": [\n        \"traditional\", \n        \"folkloric\", \n        \"surreal\", \n        \"biomech-organic fusion\", \n        \"modern minimal\"\n      ],\n      \"default\": \"traditional\"\n    },\n    \"color_palette\": {\n      \"type\": \"select\",\n      \"label\": \"Color Palette\",\n      \"options\": [\n        \"earth tones and muted greens\",\n        \"pastel shades\",\n        \"neon surreal\",\n        \"rusted metal and white florals\",\n        \"monochrome with silver threads\"\n      ],\n      \"default\": \"earth tones and muted greens\"\n    }\n  },\n  \"prompt_template\": \"{final_theme} hand-embroidered brooch, {style} style, crafted with intricate threadwork and metallic accents, soft wool and silk embroidery, fine beadwork outlining the {shape} shape, natural color palette ({color_palette}), macro shot on neutral linen or stone background, ultra-detailed artisan aesthetic, realistic embroidery textures, soft atmospheric lighting --ar 1:1 --style raw --v 6 --q 2\",\n  \"logic\": {\n    \"final_theme\": {\n      \"if\": \"reference_mode == 'describe manually'\",\n      \"value\": \"{theme_text}\"\n    },\n    \"final_theme_alt\": {\n      \"if\": \"reference_mode == 'use uploaded image'\",\n      \"value\": \"{image_reference_description}\"\n    },\n    \"final_theme_combined\": {\n      \"if\": \"reference_mode == 'combine both'\",\n      \"value\": \"{theme_text} and elements from: {image_reference_description}\"\n    }\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [
+        "{shape}、{theme}、{style} 可自己修改"
+      ],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "felt",
+        "minimalist",
+        "nature",
+        "neon"
+      ],
+      "coverImage": "images/103.png"
+    },
+    {
+      "id": 102,
+      "slug": "prompt-102",
+      "title": "纹理化图片",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1931727106590826828"
+      },
+      "images": [
+        "images/102.png"
+      ],
+      "prompts": [
+        "Retexture the image attached based on the json below\n{\n  \"style\": \"C4D hyper-realistic 3D render\",\n  \"object_form\": \"detailed mechanical design\",\n  \"geometry\": {\n    \"shape\": \"sharp edges with smooth curves\",\n    \"scale\": \"real-world proportion\",\n    \"detailing\": \"high-poly mesh with intricate mechanical features\"\n  },\n  \"material\": {\n    \"base\": \"polished plastic and carbon fiber\",\n    \"texture\": \"fine surface variation with specular maps\",\n    \"finish\": \"high gloss with realistic reflections\"\n  },\n  \"design_elements\": {\n    \"decals\": \"subtle branding and panel lines\",\n    \"surface_effects\": \"anodized gradients, emissive lighting elements\",\n    \"aero_parts\": \"spoilers, splitters, and aggressive styling cues\"\n  },\n  \"color_scheme\": {\n    \"primary\": \"#0ae2c0\",\n    \"secondary\": \"#111111\",\n    \"accents\": [\"#ffffff\", \"#e00000\"],\n    \"reflections\": \"real-world HDRI light environment\",\n    \"background\": \"#ffffff\"\n  },\n  \"lighting\": {\n    \"type\": \"studio 3-point with HDRI\",\n    \"intensity\": \"balanced with key fill and rim lights\",\n    \"shadows\": \"soft, subtle contact shadow under object\",\n    \"highlights\": \"strong specular reflections on curves\"\n  },\n  \"rendering\": {\n    \"engine\": \"Cinema 4D Redshift or Octane\",\n    \"resolution\": \"ultra high-definition (4K+)\",\n    \"focus\": \"object-centered with floating illusion\",\n    \"background_blur\": \"none\"\n  },\n  \"composition\": {\n    \"layout\": \"centered in frame\",\n    \"object_count\": 1,\n    \"orientation\": \"three-quarter front view\",\n    \"camera\": \"35mm lens, slightly elevated\",\n    \"grounding\": \"floating mid-air with realistic soft shadow cast on white background\"\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [
+        "需上传一张参考图"
+      ],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "vehicle"
+      ],
+      "coverImage": "images/102.png"
+    },
+    {
+      "id": 101,
+      "slug": "prompt-101",
+      "title": "将你的Logo变成吉祥物",
+      "source": {
+        "name": "@alex_prompter",
+        "url": "https://x.com/alex_prompter/status/1927308788610081088"
+      },
+      "images": [
+        "images/101.jpeg"
+      ],
+      "prompts": [
+        "Create a mascot for [BRAND NAME] logo following the JSON aesthetic below:\n{\n\"style\": \"brand-inspired creative mascot generation\",\n\"subject_handling\": {\n\"adapt_to_uploaded_image\": true,\n\"preserve_uploaded_logo_shape_and_text\": true,\n\"extract_dominant_brand_colors\": true,\n\"analyze_logo_style_for_mood\": true,\n\"use_uploaded_image_as_primary_reference\": true\n},\n\"mascot_generation\": {\n\"character_type\": \"open — could be an animal, humanoid, object, robot, fantasy creature, or abstract form\",\n\"design_strategy\": \"generate a mascot concept that visually complements the uploaded brand based on extracted brand colors, mood, and style\",\n\"style_alignment\": \"mascot should feel like part of the brand family — matching tone (playful, elegant, techy, minimal, etc.)\",\n\"color_usage\": \"use brand colors as dominant tones in mascot’s body, clothing, skin, or materials\",\n\"personality_embedding\": \"include expressive traits aligned with brand tone (e.g. curious, bold, serene, confident)\"\n},\n\"composition\": {\n\"include_uploaded_logo_in_final_image\": true,\n\"arrangement\": \"mascot and logo presented together in a clear and balanced composition\",\n\"environment\": \"minimal scene or brand-aligned abstract background — not too busy\",\n\"interaction\": \"mascot may pose near, hold, or gesture to logo — but must not obscure or alter it\"\n},\n\"lighting\": {\n\"type\": \"neutral or soft directional lighting depending on brand tone\",\n\"shadow_behavior\": \"soft contact shadows to ground elements\"\n},\n\"camera\": {\n\"view_angle\": \"centered frontal or three-quarter depending on layout\",\n\"focus\": \"both mascot and logo in clear focus\"\n},\n\"post_processing\": {\n\"enhance_color harmony between mascot and logo\": true,\n\"disable_style_overrides or artistic distortion\": true\n},\n\"image_constraints\": {\n\"transparent_background\": false,\n\"aspect_ratio\": [INSERT ASPECT RATIO],\n\"include_text_if_present_in_logo\": true,\n\"preserve_uploaded_logo_geometry\": true,\n\"prevent_logo_modification\": true\n},\n\"notes\": \"Use the uploaded logo or product image as the central brand reference. Automatically generate a unique mascot that feels like an original creation belonging to the brand — inspired by extracted colors, shapes, and mood. The mascot must not copy other mascots or use predefined templates. The final image should creatively showcase both the logo and its new mascot side-by-side, visually unified but distinct.\"\n}"
+      ],
+      "examples": [],
+      "notes": [
+        "上传一张参考图，然后调整[BRAND NAME]和[INSERT ASPECT RATIO]变量"
+      ],
+      "originFile": "200.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "branding",
+        "character",
+        "fantasy",
+        "landscape",
+        "logo",
+        "minimalist",
+        "product"
+      ],
+      "coverImage": "images/101.jpeg"
+    },
+    {
+      "id": 100,
+      "slug": "prompt-100",
+      "title": "终极跨界",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1925146916133712191"
+      },
+      "images": [
+        "images/100.png",
+        "images/100-2.jpeg",
+        "images/100-3.jpeg"
+      ],
+      "prompts": [
+        "Imagine [CHARAKTER 1] and [Charakter 2] casually sitting together at a table in a [FAST FOOD BRAND] restaurant. The atmosphere is relaxed and light-hearted, with the two characters engaged in an amusing or deep conversation over trays of food and drinks."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "character",
+        "food"
+      ],
+      "coverImage": "images/100.png"
+    },
+    {
+      "id": 99,
+      "slug": "prompt-99",
+      "title": "玩具盒中的历史",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1925223613055017251"
+      },
+      "images": [
+        "images/99.png",
+        "images/99-2.jpeg"
+      ],
+      "prompts": [
+        "An ultra-realistic top-down photograph of a 3D-printed diorama inside a beige cardboard box, with the lid being held open by two human hands. The interior of the box reveals a miniature landscape of [COUNTRY NAME], featuring iconic landmarks, terrain, buildings, rivers, vegetation, and crowds of tiny, detailed human figures. The diorama is filled with vibrant, geographically appropriate elements, all crafted in a tactile, toy-like style using matte 3D-printed textures with visible layer lines. At the top, the inside of the box lid displays the phrase “[COUNTRY NAME]” in large, colorful, raised plastic letters—each letter in a different bright color. The lighting is warm and cinematic, highlighting the textures and shadows to evoke a sense of realism and charm, as if the viewer is opening a magical miniature version of the natio"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "interior",
+        "landscape",
+        "photography",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/99.png"
+    },
+    {
+      "id": 98,
+      "slug": "prompt-98",
+      "title": "3D卡通雕塑风格",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1925301120252924356"
+      },
+      "images": [
+        "images/98.jpeg",
+        "images/98-2.jpeg"
+      ],
+      "prompts": [
+        "a soft 3D cartoon-style sculpture of [brand product], made of smooth clay-like textures and vibrant pastel colors, placed in a minimalist isometric scene that complements the product’s nature, clean composition, gentle lighting, subtle shadows, with the product’s logo and a 3-word slogan displayed clearly belo"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "cartoon",
+        "clay",
+        "minimalist",
+        "nature",
+        "product",
+        "sculpture",
+        "vehicle"
+      ],
+      "coverImage": "images/98.jpeg"
+    },
+    {
+      "id": 97,
+      "slug": "prompt-97",
+      "title": "复古电脑开机画面解析为ASCII艺术",
+      "source": {
+        "name": "@Gdgtify",
+        "url": "https://x.com/Gdgtify/status/1925176250626159053"
+      },
+      "images": [
+        "images/97.png",
+        "images/97-2.jpeg"
+      ],
+      "prompts": [
+        "Retro CRT computer boot screen that resolves into ASCII-art of NYC's tallest building"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "retro"
+      ],
+      "coverImage": "images/97.png"
+    },
+    {
+      "id": 96,
+      "slug": "prompt-96",
+      "title": "3D蒸汽朋克Logo",
+      "source": {
+        "name": "@MayorKingAI",
+        "url": "https://x.com/MayorKingAI/status/1925144570553327620"
+      },
+      "images": [
+        "images/96.jpeg"
+      ],
+      "prompts": [
+        "3D sculpted logo of [LOGO NAME], in a steampunk style, made of aged brass and oxidized iron, with visible rivets, gears, and vintage mechanical elements, distressed and weathered surface, rich copper and bronze tones, engraved with Victorian-style filigree, retro-industrial design, soft spotlight lighting, neutral background, hyper-realistic render, ultra-high resolution, symmetrical composition"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "logo",
+        "retro"
+      ],
+      "coverImage": "images/96.jpeg"
+    },
+    {
+      "id": 95,
+      "slug": "prompt-95",
+      "title": "品牌平面纸风格",
+      "source": {
+        "name": "@HBCoop_",
+        "url": "https://x.com/HBCoop_/status/1925213900192043236"
+      },
+      "images": [
+        "images/95.png"
+      ],
+      "prompts": [
+        "A flat branded paper folds itself into the full 3D shape of a [Air Jordan 1 shoes], mid-motion. Dramatic studio lighting, origami texture detail, gradient shadows, Japanese minimalism feel.",
+        "A flat branded paper folds itself into the full 3D shape of a [Jansport backpack], mid-motion. Dramatic studio lighting, origami texture detail, gradient shadows, Japanese minimalism feel."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "paper-craft"
+      ],
+      "coverImage": "images/95.png"
+    },
+    {
+      "id": 94,
+      "slug": "prompt-94",
+      "title": "制药风格商品",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1925197464099049735"
+      },
+      "images": [
+        "images/94.jpeg"
+      ],
+      "prompts": [
+        "A square-format digital photograph showing a fictional pharmaceutical-style product from [Brand Name] Pharmacy. The box is on the left, clean and minimalist, featuring bold text with the product name \"[PRODUCT NAME]\" and a witty line like \"Take one [type] daily.\" Next to the box is a silver blister pack containing 6–10 themed pills or capsules shaped like [describe icon/logo/item, e.g., a coffee cup, burger, heart, Midjourney logo, etc.]. Neutral background, soft lighting, sharp focus, modern packaging aesthetic."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/94.jpeg"
+    },
+    {
+      "id": 93,
+      "slug": "prompt-93",
+      "title": "不同情绪状态的思想泡泡",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1925098220398465145"
+      },
+      "images": [
+        "images/93.jpeg"
+      ],
+      "prompts": [
+        "A [SUBJECT] sits alone in a minimalistic room filled with floating, semi-transparent thought bubbles. Each bubble contains a fragment of their face from different emotional states — smiling, crying, screaming — forming a psychological self-portrait suspended in mid-air."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "minimalist",
+        "portrait"
+      ],
+      "coverImage": "images/93.jpeg"
+    },
+    {
+      "id": 92,
+      "slug": "prompt-92",
+      "title": "霓虹玻璃发光",
+      "source": {
+        "name": "@alban_gz",
+        "url": "https://x.com/alban_gz/status/1925446996468371893"
+      },
+      "images": [
+        "images/92.jpeg"
+      ],
+      "prompts": [
+        "Recreate this image using the parameters from the JSON provided.\n{\n  \"name\": \"Neon Glass Glow\",\n  \"style\": {\n    \"material\": {\n      \"type\": \"glass\",\n      \"transparency\": 0.92,\n      \"reflectivity\": 1.0,\n      \"refractionIndex\": 1.6,\n      \"color\": \"#ff00ff\",\n      \"emission\": {\n        \"color\": \"#ff66ff\",\n        \"intensity\": 0.8\n      },\n      \"surfaceFinish\": \"glossy\",\n      \"bloom\": true,\n      \"detail\": \"high\"\n    },\n    \"outline\": {\n      \"enabled\": true,\n      \"color\": \"#ffccff\",\n      \"width\": 1.8\n    },\n    \"lighting\": {\n      \"type\": \"studio\",\n      \"keyLightColor\": \"#ffffff\",\n      \"keyLightIntensity\": 1.0,\n      \"fillLightColor\": \"#9900ff\",\n      \"fillLightIntensity\": 0.7,\n      \"rimLightColor\": \"#00ffff\",\n      \"rimLightIntensity\": 0.7,\n      \"shadows\": \"crisp\"\n    },\n    \"background\": {\n      \"type\": \"solid\",\n      \"color\": \"#000000\"\n    },\n    \"render\": {\n      \"shadows\": true,\n      \"antiAliasing\": true,\n      \"superSampling\": \"4x\",\n      \"resolution\": \"high\",\n      \"depthOfField\": {\n        \"enabled\": true,\n        \"focusDistance\": 0.8,\n        \"blurAmount\": 0.1\n      }\n    }\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "neon"
+      ],
+      "coverImage": "images/92.jpeg"
+    },
+    {
+      "id": 91,
+      "slug": "prompt-91",
+      "title": "动感雕塑",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1925490847564669153"
+      },
+      "images": [
+        "images/91.png"
+      ],
+      "prompts": [
+        "A kinetic sculpture of a [subject], made of interlocking metal rods and panels in brushed [color1] and oxidized [color2]. Suspended in motion, with rotating parts casting mechanical shadows on a concrete pedestal."
+      ],
+      "examples": [
+        "A kinetic sculpture of a leaping dancer, made of interlocking metal rods and panels in brushed platinum and oxidized midnight blue. Suspended in motion, with rotating parts casting mechanical shadows on a concrete pedestal."
+      ],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "sculpture"
+      ],
+      "coverImage": "images/91.png"
+    },
+    {
+      "id": 90,
+      "slug": "prompt-90",
+      "title": "将您的标志变成毛毡纹理",
+      "source": {
+        "name": "@alex_prompter",
+        "url": "https://x.com/alex_prompter/status/1925460683509899423"
+      },
+      "images": [
+        "images/90.jpeg"
+      ],
+      "prompts": [
+        "Retexture [BRAND NAME] logo following my JSON aesthetic below:\n{\n\"style\": \"realistic needle-felted wool sculpture\",\n\"subject_handling\": {\n\"adapt_to_uploaded_image\": true,\n\"preserve_original_shape_and_layout\": true,\n\"preserve_uploaded_color_values\": true,\n\"preserve_text_if_present\": true,\n\"preserve_text_case\": true,\n\"preserve_exact_letterforms\": true,\n\"use_uploaded_image_as_pixel_map\": true,\n\"prevent_color_estimation_or_stylization\": true\n},\n\"needle_felting\": {\n\"material_type\": \"dyed wool fibers matched precisely to uploaded image pixels\",\n\"texture_description\": \"fluffy soft felt with clear fiber strands\",\n\"construction_style\": \"needle-felted, light irregularities allowed but no color bleeding\",\n\"color_application_method\": \"direct color transfer from uploaded image to wool sculpture\",\n\"prevent_auto_saturation_adjustment\": true,\n\"prevent_color_fading\": true,\n\"color_binding_mode\": \"pixel-level color fidelity per original image\"\n},\n\"lighting\": {\n\"lighting_type\": \"neutral soft studio lighting\",\n\"shadow\": \"soft, gray-toned shadows under the object only\",\n\"highlight_behavior\": \"matte highlights only from felt surface — no bloom or color shift\"\n},\n\"background\": {\n\"type\": \"plain matte studio\",\n\"background_color\": \"pastel tone that contrasts with logo color\",\n\"color_conflict_handling\": \"auto-adjust background brightness — do not alter logo colors\"\n},\n\"camera\": {\n\"focus_style\": \"macro lens\",\n\"depth_of_field\": \"shallow — full subject in sharp detail, soft background\",\n\"angle\": \"frontal or slightly elevated, full subject visible\"\n},\n\"post_processing\": {\n\"color_preservation_enforced\": true,\n\"disable_auto-enhancement_or_tinting\": true,\n\"no artistic reinterpretation\": true,\n\"no auto-correction, bloom, or white balance adjustments\": true\n},\n\"image_constraints\": {\n\"transparent_background\": false,\n\"aspect_ratio_locked\": true,\n\"include_text_if_present\": true,\n\"preserve_text_case\": true,\n\"preserve_uploaded_color_values\": true,\n\"prevent_shape_or_color_change\": true,\n\"enforce_exact_pixel_color_match_to_uploaded_image\": true\n},\n\"notes\": \"The uploaded image must be converted into a needle-felted wool sculpture using its exact colors and shape. Use pixel-level mapping to apply the uploaded color values to simulated dyed wool fibers. Do not change, brighten, dull, average, or blend colors. Text must remain intact and readable. Background should be soft pastel to contrast the logo — never adjust the logo to fit the scene.\"\n}"
+      ],
+      "examples": [],
+      "notes": [
+        "上传一张图片"
+      ],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "felt",
+        "logo",
+        "pixel",
+        "sculpture"
+      ],
+      "coverImage": "images/90.jpeg"
+    },
+    {
+      "id": 89,
+      "slug": "prompt-89",
+      "title": "海洋中三艘不同的奇幻帆船",
+      "source": {
+        "name": "@BeanieBlossom",
+        "url": "https://x.com/BeanieBlossom/status/1925159751169810806"
+      },
+      "images": [
+        "images/89.jpeg"
+      ],
+      "prompts": [
+        "Three different fantasy sailboats in the ocean, multiple scenes of beautiful aurora borealis and colorful moons with snowy mountains, a dreamy, fantasy landscape, in the style of digital art."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "fantasy",
+        "landscape"
+      ],
+      "coverImage": "images/89.jpeg"
+    },
+    {
+      "id": 88,
+      "slug": "prompt-88",
+      "title": "AirBnB 任何东西",
+      "source": {
+        "name": "@R2_fieldworks",
+        "url": "https://x.com/R2_fieldworks/status/1924433924106727531"
+      },
+      "images": [
+        "images/88.png",
+        "images/88-2.png"
+      ],
+      "prompts": [
+        "A highly detailed 3D isometric icon of the following object: [OBJECT]\n\nStyle: Airbnb 2024 icon language — miniature diorama / emoji-like object with crisp edges, realistic textures, and soft handcrafted realism.  \n\nMaterial: The object should clearly retains its fundamental qualities but look as if its made from a mixture of matte and plastic-like materials.  \n\nView: three-quarter front-left isometric view with a slight top-down angle.  \n\nLighting: soft neutral studio lighting from the top-left with subtle shadows and gentle gloss highlights.  \n\nColor palette: retain the fundamental colors from the object and include subtle gradients and no harsh contrasts.  \n\nBackground: clean white, no drop shadow or noise.  \n\nMood: minimal, charming, utilitarian, premium.  \n\nRendering: hyper-detailed, photorealistic object with depth and tactility, like a designer lifestyle emoji or miniature product model. \n\nOptional Add-on for Replication:  Use the attached photo as a reference for proportions and layout. Do not copy exactly — reinterpret it in the Airbnb icon aesthetic."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "emoji",
+        "minimalist",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/88.png"
+    },
+    {
+      "id": 87,
+      "slug": "prompt-87",
+      "title": "品牌解锁童年回忆",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1925606107608715268"
+      },
+      "images": [
+        "images/87.png"
+      ],
+      "prompts": [
+        "A realistic, cinematic photograph of a vintage [BRAND NAME] item being gently lifted from a dusty stack of old children's books in a dimly lit attic. The item is designed in classic [BRAND NAME] style—featuring authentic patterns, textures, or logos (e.g. monograms, embossing, or signature motifs relevant to the brand). It is partially opened to reveal a miniature, warmly lit classroom inspired by [COUNTRY] school interiors, complete with small regional-style desks, a chalkboard with delicate handwriting in [LANGUAGE], and traditional local details like shoes, posters, or flags. A paper airplane hovers mid-air. The lighting is moody and nostalgic, with soft shadows and golden highlights suggesting afternoon light filtering through attic beams. On the top book cover at the bottom of the image, the [BRAND NAME] logo is written in an elegant, fountain-pen calligraphy style—subtle, integrated into the scene, and not obscuring the main subject."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "interior",
+        "nature",
+        "paper-craft",
+        "photography",
+        "poster",
+        "retro"
+      ],
+      "coverImage": "images/87.png"
+    },
+    {
+      "id": 86,
+      "slug": "prompt-86",
+      "title": "未来的OpenAI可穿戴设备",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1925589916844794154"
+      },
+      "images": [
+        "images/86.png"
+      ],
+      "prompts": [
+        "Create image with 1:1 ratio A next-gen wearable ai [device type] blending Jony Ive–inspired refined minimalism with a new material and interaction language symbolizing the power ChatGPT. The device is crafted from translucent aerogel fused with polished ceramic titanium, feather-light yet futuristic.  No seams, buttons, or traditional UI. Photographed floating against a pure white background, with a soft, diffused, nearly shadowless studio light."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "minimalist",
+        "photography",
+        "ui"
+      ],
+      "coverImage": "images/86.png"
+    },
+    {
+      "id": 85,
+      "slug": "prompt-85",
+      "title": "知名戏曲片段的MBTI人格类型卡片",
+      "source": {
+        "name": "@op7418",
+        "url": "https://x.com/op7418/status/1925869690120794320"
+      },
+      "images": [
+        "images/85.jpeg"
+      ],
+      "prompts": [
+        "# 任务目标\n请生成一张基于中国古代知名戏曲片段的MBTI人格类型卡片图片，使戏曲场景扁平插画的情感内涵与MBTI人格特质相对应。，我需要生成的人各类型是[INTP]\n\n## 内容要求\n1. **场景选取**：从中国古代知名戏曲片段中提取能体现不同MBTI人格特质的代表性场景\n2. **场景意境**：画面需表现完整戏剧场景，通过场景氛围体现对应的人格特质\n3. **服饰真实性**：画面中人物必须穿着对应戏曲的正确戏服\n4. **人格对应**：每个场景需精准对应一种MBTI人格类型的核心特质\n\n## 卡片排版设计\n参考图片样式：\n- **顶部**：MBTI类型代码（如INFJ）\n- **中部**：渐变色彩的抽象几何图形作为主视觉\n- **底部**：\n- 中文人格类型名称（如\"提倡者\"）\n- 英文标语：（如\"The world is your oyster\"）\n- 装饰性边框和星形符号\n\n## 视觉风格\n- 采用现代极简设计语言\n- 渐变色彩与几何形状结合\n- 保持神秘感与艺术性\n- 整体色调柔和梦幻\n\n## 技术规格\n- 卡片尺寸采用标准比例\n- 每张卡片需清晰标注MBTI类型代码\n- 保持系列视觉一致性"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "landscape",
+        "minimalist",
+        "portrait",
+        "typography"
+      ],
+      "coverImage": "images/85.jpeg"
+    },
+    {
+      "id": 84,
+      "slug": "prompt-84",
+      "title": "渐变挤出Google I/O 2025大会视觉效果",
+      "source": {
+        "name": "@hckmstrrahul",
+        "url": "https://x.com/hckmstrrahul/status/1925567579856453701"
+      },
+      "images": [
+        "images/84.jpeg",
+        "images/84-2.jpeg"
+      ],
+      "prompts": [
+        "Retexture this image in the following JSON style aesthetic:\n{\n  \"styleAesthetic\": {\n    \"title\": \"Isometric Multicolor Extrusion with Grid Control\",\n    \"overallVibe\": \"Playful modern 3D iconography with directional extrusion and dynamic isometric grids\",\n    \"viewAngle\": {\n      \"type\": \"Isometric\",\n      \"facingDirection\": \"right\",  // options: left, right, front\n      \"rotationDegrees\": {\n        \"x\": 30,\n        \"y\": 30\n      }\n    },\n    \"renderingStyle\": \"Clean 3D extruded vector with soft lighting and high contrast between faces\",\n    \"objectSurface\": {\n      \"frontFace\": {\n        \"color\": \"#ffffff\",\n        \"material\": \"Matte white plastic\",\n        \"lighting\": \"Soft diffuse\"\n      },\n      \"extrudedSide\": {\n        \"type\": \"Multicolor gradient\",\n        \"gradientStyle\": \"Diagonal sweep\",\n        \"colorStops\": [\n          \"#ff0040\", \"#ff8000\", \"#ffff00\", \"#00ff90\", \"#00cfff\", \"#8000ff\"\n        ],\n        \"material\": \"Glossy plastic\",\n        \"lighting\": \"Ambient with light falloff\"\n      }\n    },\n    \"extrusion\": {\n      \"direction\": \"right\",  // determines which side is extruded: left, right, front\n      \"depth\": \"moderate\"\n    },\n    \"shadows\": {\n      \"type\": \"Drop shadow\",\n      \"direction\": \"bottom-right\",\n      \"opacity\": 0.15,\n      \"blurRadius\": \"6px\"\n    },\n    \"background\": {\n      \"type\": \"Isometric grid\",\n      \"color\": \"#ffffff\",\n      \"gridStyle\": {\n        \"lineColor\": \"#e0e0e0\",\n        \"lineWeight\": \"1px\",\n        \"orientation\": \"opposite-extrusion\"  // automatically flips grid lines to oppose the extrusion direction\n      }\n    },\n    \"moodKeywords\": [\n      \"Dimensional\",\n      \"Clean\",\n      \"Geometric\",\n      \"Colorful\",\n      \"Tactile\",\n      \"Structured\"\n    ]\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/84.jpeg"
+    },
+    {
+      "id": 83,
+      "slug": "prompt-83",
+      "title": "Glitch 矢量徽标样式",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1925844468294365289"
+      },
+      "images": [
+        "images/83.png"
+      ],
+      "prompts": [
+        "A bold vector logo design in glitch art style, featuring distorted typography with RGB color channel shifts, fragmented lines, misaligned edges, digital noise effects, and a cyberpunk aesthetic. The logo appears corrupted or hacked, as if captured from a malfunctioning screen. Use a black or dark background for contrast, neon or high-saturation color palette, and sharp angular forms.",
+        "1、\"X-CODE\" in futuristic glitch style, with pixel breakups and neon overlays\n2、A glitch vector logo for a rogue AI named “OBLIVION.EXE”, with red error overlays and corrupted circuitry\n3、A circular emblem for “Station 404”, a hacked orbital base with broken planetary symbols and static flicker\n4、A surveillance eye logo, distorted with chromatic aberration, layered static, and flickering digital interference"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "示例想法：",
+      "tags": [
+        "futuristic",
+        "neon",
+        "pixel",
+        "sci-fi",
+        "typography"
+      ],
+      "coverImage": "images/83.png"
+    },
+    {
+      "id": 82,
+      "slug": "prompt-82",
+      "title": "霓虹花卉和谐插图",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1926246931661042132"
+      },
+      "images": [
+        "images/82.png"
+      ],
+      "prompts": [
+        "A Neon Floral Harmony illustration of [SUBJECT], with flowers and plants outlined in glowing neon hues. Use vibrant [COLOR1] and [COLOR2] to create a serene yet electrifying botanical scene"
+      ],
+      "examples": [
+        "A Neon Floral Harmony illustration of a graceful hummingbird, with flowers and plants outlined in glowing neon hues. Use vibrant turquoise and magenta to create a serene yet electrifying botanical scene"
+      ],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "nature",
+        "neon"
+      ],
+      "coverImage": "images/82.png"
+    },
+    {
+      "id": 81,
+      "slug": "prompt-81",
+      "title": "品牌乐器",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1926148686884606257"
+      },
+      "images": [
+        "images/81.png"
+      ],
+      "prompts": [
+        "A highly stylized and vibrant promotional image of a [INSTRUMENT] designed in the visual style of the [BRAND] brand — the instrument is reimagined with iconic colors, patterns, and aesthetic elements of the brand. Set in a dynamic, music-inspired environment, with glowing accents, product-style lighting, and joyful energy. Artistic fusion of music and design. 3D render look, high detail, vibrant colors, futuristic but playful."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "futuristic",
+        "landscape",
+        "product"
+      ],
+      "coverImage": "images/81.png"
+    },
+    {
+      "id": 80,
+      "slug": "prompt-80",
+      "title": "水果的形状",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1926182194159972503"
+      },
+      "images": [
+        "images/80.jpeg"
+      ],
+      "prompts": [
+        "Create an image by arranging [NUMBER/AGGREGATE] of [FRUIT] strategically on a dark surface to form the shape of [OBJECT/EMOJI/LOGO]"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "emoji",
+        "logo"
+      ],
+      "coverImage": "images/80.jpeg"
+    },
+    {
+      "id": 79,
+      "slug": "prompt-79",
+      "title": "Alloy图标",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1926095406871568670"
+      },
+      "images": [
+        "images/79.jpeg"
+      ],
+      "prompts": [
+        "create image with 1: 1 ratio  \nturn a vector [ type\n] icon with the following json style \n{\n    \"object\": \"icon\",\n    \"material\": {\n        \"primary_surface\": \"smooth matted translucent metallic\",\n        \"finish\": \"iridescent sheen\",\n        \"color_profile\": {\n            \"base_color\": \"deep blue\",\n            \"secondary_tones\": [\n                \"black\",\n                \"violet\",\n                \"copper-orange highlights\"\n            ]\n        },\n        \"panel_lines\": {\n            \"material\": \"metallic copper\",\n            \"visual_treatment\": \"glowing edge with subtle bevel\"\n        },\n    },\n    \"lighting\": {\n        \"type\": \"studio\",\n        \"key_light\": {\n            \"position\": \"top-left\",\n            \"effect\": \"smooth gradient highlight across the surface\"\n        },\n        \"rim_light\": {\n            \"position\": \"right side\",\n            \"effect\": \"sharp metallic edge glow\"\n        },\n        \"reflections\": {\n            \"character\": \"diffused but iridescent, hinting at a highly polished or lacquered surface\"\n        },\n        \"shadows\": \"soft edge, minimal ground contact due to floating presentation\"\n    },\n    \"background\": {\n        \"color\": \"#FFF\",\n        \"style\": \"solid matte\",\n    },\n    \"composition\": {\n        \"camera_angle\": \"centered, eye-level\",\n        \"depth_of_field\": \"none (sharp focus throughout)\",\n        \"presentation\": \"floating, isolated subject\"     \"angle\": \"isometric style\"\n    },\n    \"visual_style\": {\n        \"tone\": \"modern, high-impact\",\n        \"inspiration\": \"sports branding meets futuristic product design\",\n        \"aesthetic\": \"bold contrast, tech-luxury fusion\"\n    }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "character",
+        "futuristic",
+        "minimalist",
+        "product"
+      ],
+      "coverImage": "images/79.jpeg"
+    },
+    {
+      "id": 78,
+      "slug": "prompt-78",
+      "title": "毛绒形式表情符号",
+      "source": {
+        "name": "@alban_gz",
+        "url": "https://x.com/alban_gz/status/1925833589431619616"
+      },
+      "images": [
+        "images/78.png"
+      ],
+      "prompts": [
+        "Recreate this [insert emoji] using the parameters from the JSON provided.\n{\n  \"style\": \"Plushform Emoji\",\n  \"description\": \"Transform the emoji into a soft, realistic plush object with high-quality fabric and detailed construction. Do not anthropomorphize the emoji — avoid adding faces or cartoon features. Focus on accurate textures, natural forms, and subtle design to give the plush object character.\",\n  \"features\": {\n    \"shape\": \"matching the emoji's form, with soft, slightly rounded plush adaptation\",\n    \"texture\": \"realistic plush fabric with visible fiber detail and natural fabric folds\",\n    \"color\": \"faithful to the emoji's palette, using slightly muted, tactile tones\",\n    \"material\": \"stuffed toy fabric with visible stitching, seams, and high-quality finishing\",\n    \"background\": \"neutral or softly textured to emphasize the plush object's form\",\n    \"lighting\": \"soft professional studio lighting with subtle shadows and depth\"\n  },\n  \"examples\": [\n    \"👌 becomes a plush hand in the OK gesture, with realistic fabric folds and seams.\",\n    \"🎯 becomes a soft plush bullseye with layered fuzzy rings and slight dimensional padding.\",\n    \"🎁 becomes a cube-shaped plush box with fabric ribbon, visible stitching, and realistic fabric texture.\",\n    \"🌊 becomes a wave-shaped plush with curled foam tips, crafted in textured ocean blue fabrics.\"\n  ]\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "emoji",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/78.png"
+    },
+    {
+      "id": 77,
+      "slug": "prompt-77",
+      "title": "3D零食卡通世界",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1925895453217898847"
+      },
+      "images": [
+        "images/77.jpeg"
+      ],
+      "prompts": [
+        "A 3D-rendered digital illustration featuring a retro-style food truck inspired by the brand [INSERT BRAND NAME], designed with smooth pastel colors and soft textures. A black-and-white cartoon character stands beside the truck, holding a product that visually represents the brand. The environment reflects the brand’s world—playful hills, trees, and skies stylized with its color palette and product shapes. The brand’s logo is clearly displayed on the truck, and a short slogan appears naturally within the scene. Format: 1:1, isometric view, cinematic lighting, clean and joyful composition."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "cartoon",
+        "character",
+        "food",
+        "illustration",
+        "landscape",
+        "product",
+        "retro",
+        "vehicle"
+      ],
+      "coverImage": "images/77.jpeg"
+    },
+    {
+      "id": 76,
+      "slug": "prompt-76",
+      "title": "黑白漫画风格插图",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1923778050845528388"
+      },
+      "images": [
+        "images/76.png"
+      ],
+      "prompts": [
+        "Highly dramatic and epic black and white manga-style illustration of [Your character and description].  Powerful, dynamic pose, exaggerated features emphasizing the intensity of the scene. Background with explosive energy bursts, lightning effects, and a whirlwind of debris"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "character",
+        "illustration"
+      ],
+      "coverImage": "images/76.png"
+    },
+    {
+      "id": 75,
+      "slug": "prompt-75",
+      "title": "可爱干净的底座立体模型",
+      "source": {
+        "name": "@CharaspowerAI",
+        "url": "https://x.com/CharaspowerAI/status/1925593447802540408"
+      },
+      "images": [
+        "images/75.png",
+        "images/75-2.png"
+      ],
+      "prompts": [
+        "Highly detailed 3D-rendered chibi figurine diorama of [Character A] and [Character B], captured in a [scene/action], inside a [thematic display case shape] with [material]. The background features [visual effects: debris, aura, lightning, scenery], dynamic pose. The title \"[custom phrase]\" is embossed at the top in [font/style], matching the tone. Lighting is [studio, cinematic, ambient], color palette of [main colors]. Designed in a collectible, stylized, viral-friendly aesthetic."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "character",
+        "toy"
+      ],
+      "coverImage": "images/75.png"
+    },
+    {
+      "id": 74,
+      "slug": "prompt-74",
+      "title": "3D可爱粉彩粘土图标",
+      "source": {
+        "name": "@icreatelife",
+        "url": "https://x.com/icreatelife/status/1926014358783430945"
+      },
+      "images": [
+        "images/74.png"
+      ],
+      "prompts": [
+        "Tiny cute isometric [smiling - optional] [OBJECT] emoji, shape, soft lighting, soft pastel colors, [COLOR], 3d icon clay render, blender 3d, pastel background"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "clay",
+        "emoji"
+      ],
+      "coverImage": "images/74.png"
+    },
+    {
+      "id": 73,
+      "slug": "prompt-73",
+      "title": "有趣的毛茸茸字母",
+      "source": {
+        "name": "@Anima_Labs",
+        "url": "https://x.com/Anima_Labs/status/1925933980781535629"
+      },
+      "images": [
+        "images/73.png"
+      ],
+      "prompts": [
+        "A highly realistic 3D render of the letter [A-Z] designed as a full-body fluffy monster. The letter shape itself is the creature’s body — no separate head or limbs. The eyes, mouth, and other monster features are embedded naturally into the letter form. The monster expresses a [mischievous / grumpy / shy / joyful / sleepy / surprised / confident] emotion through its eyes and mouth shape. The texture is dense, soft, and realistic fur, with subtle volume and shadow. The color palette is bold but clean — solid vibrant tones like mint, lilac, sky blue, or coral (avoid rainbow gradients). Studio lighting on a simple pastel background. No hats, no party props — just a minimal, high-quality character design with playful expression."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "character",
+        "minimalist"
+      ],
+      "coverImage": "images/73.png"
+    },
+    {
+      "id": 72,
+      "slug": "prompt-72",
+      "title": "超现实主义油画",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1926217150093549680"
+      },
+      "images": [
+        "images/72.png"
+      ],
+      "prompts": [
+        "A surreal oil painting of a [subject], executed in the style of early 20th-century dreamscapes. Melting shapes, floating forms, and swirling [color1] and [color2] brushstrokes create a dreamlike dissonance."
+      ],
+      "examples": [
+        "A surreal oil painting of a man with a candle for a head, executed in the style of early 20th-century dreamscapes. Melting shapes, floating forms, and swirling burnt orange and midnight blue brushstrokes create a dreamlike dissonance."
+      ],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/72.png"
+    },
+    {
+      "id": 71,
+      "slug": "prompt-71",
+      "title": "景观洞穴入口的形状",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1925819339413836010"
+      },
+      "images": [
+        "images/71.png"
+      ],
+      "prompts": [
+        "Prompt: An image of a [TYPE] landscape, featuring a cave entrance that is shaped exactly like the outline of a [SHAPE]. The cave should blend naturally into the rugged terrain of the mountain, with the entrance forming a clear and unmistakable [SHAPE] shape. This [SHAPE] shape should be simple and defined, without intricate details, emphasizing just the overall [SHAPE] outline. The surrounding environment should include [DETAILS], but these elements should not distract from the cave's   [SHAPE]-shaped entrance. The lighting in the scene should enhance the visibility and distinctiveness of the [SHAPE]-shaped cave entrance."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "landscape"
+      ],
+      "coverImage": "images/71.png"
+    },
+    {
+      "id": 70,
+      "slug": "prompt-70",
+      "title": "重新构想的玫瑰金",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1925933649267970074"
+      },
+      "images": [
+        "images/70.jpeg"
+      ],
+      "prompts": [
+        "Design a luxury-themed 1:1 image featuring a rose gold sculpture that embodies the essence of the jewelry brand “[BRAND NAME]”. The object must symbolically reflect the brand’s identity (e.g., falcon for Cartier, ring for Tiffany & Co., palm tree for Swarovski, camel for Prada). Embed premium crystal textures into key parts of the sculpture (e.g., wings, gem, leaves, or hump) to match the brand’s signature elegance. Use the brand’s iconic background color (e.g., Tiffany Blue, Swarovski White, Cartier Beige, Prada Sand) and place the official logo beneath the sculpture. Add a bold two-word slogan that aligns with the brand’s tone. Lighting should be pure white with high Kelvin value to ensure clarity and prevent yellow tint. The result must feel editorial, artistic, and visually exquisite."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "nature",
+        "sculpture",
+        "vehicle"
+      ],
+      "coverImage": "images/70.jpeg"
+    },
+    {
+      "id": 69,
+      "slug": "prompt-69",
+      "title": "品牌折叠纸",
+      "source": {
+        "name": "@HBCoop_",
+        "url": "https://x.com/HBCoop_/status/1925600123200881024"
+      },
+      "images": [
+        "images/69.png"
+      ],
+      "prompts": [
+        "A flat branded paper folds itself into the full 3D shape of a [insert product or item, e.g. “Coca-Cola bottle”, “Nike sneaker”, “Big Mac”], mid-motion. \n\nThe paper colors match the [insert brand name] brand’s signature palette and the natural colors of the item (e.g., [describe key colors or ingredients, like “red and white for Coca-Cola”, “brown, green, yellow for Big Mac”]).\n\nDramatic studio lighting, origami texture detail, soft gradient shadows. Stylized with Japanese minimalism and elegant negative space. The scene captures a clean, elevated transformation from flat brand identity into sculptural product form."
+      ],
+      "examples": [
+        "A flat branded paper folds itself into the full 3D shape of a Tesla Cybertruck, mid-motion. Paper colors match Tesla’s sleek minimal palette: matte silver with black glass panels and red accent lines. Dramatic studio lighting, origami texture detail, gradient shadows, Japanese minimalism feel. No text."
+      ],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "nature",
+        "paper-craft",
+        "product",
+        "sci-fi"
+      ],
+      "coverImage": "images/69.png"
+    },
+    {
+      "id": 68,
+      "slug": "prompt-68",
+      "title": "透明容器里有一个微型的3D世界",
+      "source": {
+        "name": "@KoppulaMahende9",
+        "url": "https://x.com/KoppulaMahende9/status/1920442464810270851"
+      },
+      "images": [
+        "images/68.png"
+      ],
+      "prompts": [
+        "A giant [transparent or glossy] [object/container] with a miniature 3D diorama inside it, depicting [a symbolic or narrative scene], studio-lit with soft shadows, placed on a neutral matte surface. Emphasize visual contrast between the scale of the capsule and the detail within. Highlight texture, light refraction, and emotional tone (e.g., surreal, poetic, or sci-fi)."
+      ],
+      "examples": [
+        "A giant glossy Water dropletwith a miniature 3D diorama inside it, depicting a Harvesting scene, studio-lit with soft shadows, placed on a neutral matte surface. Emphasize visual contrast between the scale of the capsule and the detail within. Highlight texture, light refraction, and emotional tone hyper-realistic."
+      ],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "sci-fi"
+      ],
+      "coverImage": "images/68.png"
+    },
+    {
+      "id": 67,
+      "slug": "prompt-67",
+      "title": "可爱微缩场景",
+      "source": {
+        "name": "@ZHO_ZHO_ZHO",
+        "url": "https://x.com/ZHO_ZHO_ZHO/status/1925878276133708224"
+      },
+      "images": [
+        "images/67.jpeg"
+      ],
+      "prompts": [
+        "{\n    \"style\": \"miniature handcrafted diorama\",\n    \"material\": \"tree branches, cardboard, clay, moss, dried flowers, paper\",\n    \"surface_texture\": \"organic, rough and varied (wood grain, soft moss, paper texture)\",\n    \"lighting\": {\n        \"type\": \"soft ambient natural light\",\n        \"intensity\": \"low to moderate\",\n        \"direction\": \"diffused overhead\",\n        \"accent_colors\": [\n            \"forest green\",\n            \"earth brown\",\n            \"soft beige\",\n            \"muted pink\"\n        ],\n        \"reflections\": false,\n        \"refractions\": false,\n        \"dispersion_effects\": false,\n        \"bloom\": false\n    },\n    \"color_scheme\": {\n        \"primary\": \"natural greens and browns\",\n        \"secondary\": \"soft neutral tones (cardboard, clay, paper)\",\n        \"highlights\": \"light falling on the open book and cat’s glasses\",\n        \"rim_light\": \"subtle natural edge light from the forest opening\"\n    },\n    \"background\": {\n        \"color\": \"natural moss green\",\n        \"vignette\": false,\n        \"texture\": \"moss and dried floral structure\"\n    },\n    \"post_processing\": {\n        \"chromatic_aberration\": false,\n        \"glow\": false,\n        \"high_contrast\": false,\n        \"sharp_details\": true,\n        \"film_grain\": false\n    },\n    \"form_composition\": {\n        \"scene_elements\": [\n            \"a small girl sitting on a balcony holding an open miniature book\",\n            \"a cat with glasses observing the book's illustrations\",\n            \"a treehouse made from twigs, cardboard, and clay\",\n            \"balcony and surrounding forest made of moss and dried flowers\"\n        ],\n        \"scale\": \"miniature\",\n        \"theme\": \"childlike wonder and storytelling in a handcrafted world\",\n        \"visual_metaphor\": [\n            \"curiosity\",\n            \"quiet companionship\",\n            \"imagination in nature\"\n        ]\n    },\n    \"metadata\": {\n        \"artist\": \"-Zho-\",\n        \"series\": \"ZH4O\"\n    }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "clay",
+        "illustration",
+        "landscape",
+        "nature",
+        "paper-craft",
+        "vehicle"
+      ],
+      "coverImage": "images/67.jpeg"
+    },
+    {
+      "id": 66,
+      "slug": "prompt-66",
+      "title": "霓虹灯风格工具",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1926005869331849235"
+      },
+      "images": [
+        "images/66.png"
+      ],
+      "prompts": [
+        "retexture the image attached based on the JSON aesthetic below\n{\n  \"style\": \"hyperrealistic 3D render\",\n  \"material\": \"high-gloss translucent rubber with iridescent coating\",\n  \"surface_texture\": \"fine-grain pebbling with micro-specular highlights\",\n  \"lighting\": {\n    \"type\": \"studio HDRI\",\n    \"intensity\": \"high\",\n    \"direction\": \"multi-point with rim and backlight\",\n    \"colors\": [\"electric blue\", \"magenta\", \"neon purple\", \"sunset orange\"],\n    \"glow_effect\": true,\n    \"chromatic_aberration\": true,\n    \"bloom\": true\n  },\n  \"color_scheme\": {\n    \"primary\": \"iridescent gradient\",\n    \"highlights\": \"white light core reflections\",\n    \"accent_edges\": \"black outlines with subtle glow\"\n  },\n  \"background\": {\n    \"color\": \"solid black\",\n    \"texture\": \"none\",\n    \"contrast\": \"extreme to enhance subject glow\"\n  },\n  \"camera\": {\n    \"angle\": \"straight-on center view\",\n    \"focus\": \"sharp foreground, no depth blur\",\n    \"lens\": \"macro with light distortion\"\n  },\n  \"post_processing\": {\n    \"glow\": true,\n    \"contrast_boost\": true,\n    \"color_grading\": \"vibrant spectrum\",\n    \"noise\": \"minimal\"\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "minimalist",
+        "neon"
+      ],
+      "coverImage": "images/66.png"
+    },
+    {
+      "id": 65,
+      "slug": "prompt-65",
+      "title": "皱巴巴的纸片",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1925868463689462049"
+      },
+      "images": [
+        "images/65.jpeg"
+      ],
+      "prompts": [
+        "A photorealistic image of the word '[NAME]' spelled out using torn, highly crumpled pieces of white paper. Each letter is painted in bold [COLOR] on individual scraps, arranged loosely and unevenly, as if placed casually by hand, on a wooden table. The composition should convey a natural, handmade aesthetic with visible creases, shadows, and wood grain detail"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "paper-craft",
+        "photography"
+      ],
+      "coverImage": "images/65.jpeg"
+    },
+    {
+      "id": 64,
+      "slug": "prompt-64",
+      "title": "洞壁画",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1925854528831643689"
+      },
+      "images": [
+        "images/64.png"
+      ],
+      "prompts": [
+        "A cave painting of a [subject], rendered with primitive ochres and charcoal lines on a rough stone wall. Smudged handprints, crude geometry, and flickering torchlight add a primal, ancient mood."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/64.png"
+    },
+    {
+      "id": 63,
+      "slug": "prompt-63",
+      "title": "选择你的阵营",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1925595213726097803"
+      },
+      "images": [
+        "images/63.jpeg"
+      ],
+      "prompts": [
+        "A dramatic cinematic scene featuring two rival products placed side by side in a custom-designed environment that visually reflects their identities. The composition should include high contrast lighting, atmospheric effects like mist, fog, or neon glow, and hyper-detailed textures. Incorporate a powerful 3D slogan below or behind the products in bold stylized typography that fits the scene’s mood. The products must reflect the essence of [Brand A] and [Brand B] through color, lighting, and placement. Ultra-realistic, moody tones, 1:1 square format, with sharp depth of field and high resolution."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "landscape",
+        "neon",
+        "product",
+        "typography"
+      ],
+      "coverImage": "images/63.jpeg"
+    },
+    {
+      "id": 62,
+      "slug": "prompt-62",
+      "title": "品牌设计指南海报",
+      "source": {
+        "name": "@ai4everyday",
+        "url": "https://x.com/ai4everyday/status/1925838516979646795"
+      },
+      "images": [
+        "images/62.jpeg"
+      ],
+      "prompts": [
+        "Create a vertical 9:16 brand design guide poster using the uploaded product image. Adapt the design style to match the product’s niche and visual identity. Structure the poster with clear, elegant sections: (1) Large logo display and safe zone usage, (2) Product mockup centered and highlighted, (3) Primary and secondary color palette swatches with hex codes, (4) Typography guide with heading, subheading, body font samples, and line spacing specs, (5) Iconography or graphic motif examples used by the brand, (6) Image treatment style with sample lifestyle or studio visuals, (7) Grid system or layout rules, (8) Packaging mockups and surface applications, (9) Do’s & Don’ts with annotated visuals. Use minimalist white or soft neutral background with structured layout dividers and drop shadows. The result must be visually rich, clean, and suitable for a printed or digital brand book."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "poster",
+        "product",
+        "typography"
+      ],
+      "coverImage": "images/62.jpeg"
+    },
+    {
+      "id": 61,
+      "slug": "prompt-61",
+      "title": "破碎的真相",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1925918144163450890"
+      },
+      "images": [
+        "images/61.png"
+      ],
+      "prompts": [
+        "A close-up of [SUBJECT 1] holding a mirror shard to their face. The shard reflects a completely different [SUBJECT 2]. Around them, small cracks spread through the air like fractures in invisible glass, warping the space itself."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/61.png"
+    },
+    {
+      "id": 60,
+      "slug": "prompt-60",
+      "title": "令人垂涎欲滴的广告",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1925470550035476622"
+      },
+      "images": [
+        "images/60.jpeg"
+      ],
+      "prompts": [
+        "a vertical 2:3 high-resolution food advertisement featuring the most iconic and delicious product from a well-known brand called [INSERT BRAND NAME]. The product appears centered with mouthwatering details — such as melted cheese, dripping chocolate, whipped cream, or condensation — depending on the product. The background should be a gradient or pastel tone inspired by the brand’s identity. At the top, display a bold slogan in a color that matches the brand’s style. At the bottom, include the official logo of the brand. Use cinematic studio lighting, soft shadows, and ultra-sharp textures to create a visually irresistible and minimal poster."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "food",
+        "minimalist",
+        "poster",
+        "product"
+      ],
+      "coverImage": "images/60.jpeg"
+    },
+    {
+      "id": 59,
+      "slug": "prompt-59",
+      "title": "军事计划",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1925479609442738486"
+      },
+      "images": [
+        "images/59.png"
+      ],
+      "prompts": [
+        "A humorous cartoon scene set inside a military training classroom, featuring a group of [Insect Name] soldiers sitting at desks, wearing tiny helmets and miniature combat gear. They listen attentively to their commander, who stands in front of a large board displaying a sketch of a threat to their existence — the enemy changes depending on the animal or insect. The commander explains the attack plan using a pointer, highlighting sensitive targets with red circles. Some soldiers take notes, others whisper tactical ideas to each other. The overall atmosphere blends seriousness with satire in an exaggerated cartoon style."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "cartoon",
+        "interior",
+        "vehicle"
+      ],
+      "coverImage": "images/59.png"
+    },
+    {
+      "id": 58,
+      "slug": "prompt-58",
+      "title": "血月下的决斗",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1925509492298375388"
+      },
+      "images": [
+        "images/58.png"
+      ],
+      "prompts": [
+        "[SUBJECT] in a cinematic painting, battling amid crumbling ruins under a colossal blood moon — ambient sparks flying. Set in an ancient valley, illuminated by firelight and shadows. soft [COLOR1] and vibrant [COLOR2], mood intense and epic."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/58.png"
+    },
+    {
+      "id": 57,
+      "slug": "prompt-57",
+      "title": "手工毛线纹理",
+      "source": {
+        "name": "@ecommartinez",
+        "url": "https://x.com/ecommartinez/status/1925272798479405479"
+      },
+      "images": [
+        "images/57.png"
+      ],
+      "prompts": [
+        "Crea un render 3D fotorrealista de este logo hecho con hilo grueso y tejido a mano. El hilo debe parecer suave, esponjoso y de gran tamaño, con patrones visibles de tejido como bucles, giros y trenzas. Usa colores brillantes y saturados, estética cálida. Resalta la textura de las fibras, la suavidad del material y el acabado artesanal. Iluminación de estudio suave. Fondo blanco o crema limpio. El logo debe estar centrado y sin elementos adicionales. Cuadrado."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/57.png"
+    },
+    {
+      "id": 56,
+      "slug": "prompt-56",
+      "title": "玻璃盒内的图像可视化",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1925462472825442469"
+      },
+      "images": [
+        "images/56.jpeg"
+      ],
+      "prompts": [
+        "photorealistic image of a [COLOR] 3D [SUBJECT] encased in a luxurious transparent box, viewed from an enhanced side angle to better reveal the 3D shape of the [SUBJECT]. The box should be white, exquisitely designed, featuring crystal-clear glass with refined, sharp edges"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "photography"
+      ],
+      "coverImage": "images/56.jpeg"
+    },
+    {
+      "id": 55,
+      "slug": "prompt-55",
+      "title": "彩色卡通俏皮图标和徽标",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1925553233881145499"
+      },
+      "images": [
+        "images/55.jpeg"
+      ],
+      "prompts": [
+        "Create a 2D digital illustration of the [FIREFOX] logo in a colorful cartoon style with bold black outlines. The icon design should feature playful, vibrant solid colors such as pink, teal, orange, yellow, and purple, applied in a flat, bold way. Give the shapes a slightly exaggerated, bubbly form with rounded edges and fun details like starbursts, stripes, or spark effects if relevant. Keep the illustration simple and stylized with a hand-drawn look. Use thick outlines to emphasize form. Vector friendly. White background. Square aspect ratio."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "illustration",
+        "vehicle"
+      ],
+      "coverImage": "images/55.jpeg"
+    },
+    {
+      "id": 54,
+      "slug": "prompt-54",
+      "title": "三种形状和三种颜色",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1925569394924740817"
+      },
+      "images": [
+        "images/54.jpeg"
+      ],
+      "prompts": [
+        "Create a minimalist image of a [SUBJECT] using three geometric shapes, using a different color in each shape"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "minimalist"
+      ],
+      "coverImage": "images/54.jpeg"
+    },
+    {
+      "id": 53,
+      "slug": "prompt-53",
+      "title": "由鲜花组成的小房子",
+      "source": {
+        "name": "@BeanieBlossom",
+        "url": "https://x.com/BeanieBlossom/status/1925461720639971505"
+      },
+      "images": [
+        "images/53.jpeg"
+      ],
+      "prompts": [
+        "A small house made of flowers, a tree with colorful leaves growing on top and around the door, in the style of fantasy, mountainscape in the background, natural lighting, soft colors, rich details, and a full atmosphere, subtle painterly style"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "fantasy",
+        "nature"
+      ],
+      "coverImage": "images/53.jpeg"
+    },
+    {
+      "id": 52,
+      "slug": "prompt-52",
+      "title": "清洁琴键的小人物",
+      "source": {
+        "name": "@BeanieBlossom",
+        "url": "https://x.com/BeanieBlossom/status/1925522114972713147"
+      },
+      "images": [
+        "images/52.jpeg"
+      ],
+      "prompts": [
+        "tilt-shift photo of a grand piano keyboard, side view from the left looking along the keys to the right, shallow depth of field, tiny human figures cleaning the piano keys with brushes, cloths, and buckets, whimsical and surreal scene, soft lighting, hyper-detailed, high realism"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "photography",
+        "portrait"
+      ],
+      "coverImage": "images/52.jpeg"
+    },
+    {
+      "id": 51,
+      "slug": "prompt-51",
+      "title": "霓虹灯发光的可爱动物",
+      "source": {
+        "name": "@icreatelife",
+        "url": "https://x.com/icreatelife/status/1923819449305509924"
+      },
+      "images": [
+        "images/51.png"
+      ],
+      "prompts": [
+        "bioluminescent cute [ANIMAL], kawaii, chibi, [COLOR] neon backlit, 3d cartoon, big cute bright eyes, high definition"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "animal",
+        "cartoon",
+        "neon",
+        "vehicle"
+      ],
+      "coverImage": "images/51.png"
+    },
+    {
+      "id": 50,
+      "slug": "prompt-50",
+      "title": "通过钥匙孔看世界",
+      "source": {
+        "name": "@icreatelife",
+        "url": "https://x.com/icreatelife/status/1925268371227971871"
+      },
+      "images": [
+        "images/50.png"
+      ],
+      "prompts": [
+        "looking through a [MATERIAL] keyhole towards a mythical [WORLD] dark fantasy, [very black background] around keyhole, sharp focus, photographic"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "fantasy",
+        "photography"
+      ],
+      "coverImage": "images/50.png"
+    },
+    {
+      "id": 49,
+      "slug": "prompt-49",
+      "title": "超现实海洋图案",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1925424557638500838"
+      },
+      "images": [
+        "images/49.jpeg"
+      ],
+      "prompts": [
+        "Create a hyper-realistic image where [SHAPE] shape is formed by the magical parting of [wavy] blue ocean, with the [SHAPE] shape being a [COLOUR] empty land. The top view should show the water being pushed aside by an unseen force, creating the [SHAPE] with an ultra-thin line. The stark [COLOR] color of the [SHAPE] interior should contrast with the vibrant blue water around it, emphasizing the supernatural effect as if the water is being parted to reveal the [SHAPE] shape distinctly."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "interior"
+      ],
+      "coverImage": "images/49.jpeg"
+    },
+    {
+      "id": 48,
+      "slug": "prompt-48",
+      "title": "警方照片风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1925475465029919163"
+      },
+      "images": [
+        "images/48.png"
+      ],
+      "prompts": [
+        "Transform this image into a realistic police mugshot.\nAdd a gray background with height markings, harsh frontal lighting, and a nameplate with the person's name and a case number.\nThe photo should look like an official FBI or police booking photo, vertical format (4:5), with a neutral expression and no accessories."
+      ],
+      "examples": [],
+      "notes": [
+        "上传一张图片"
+      ],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "photography"
+      ],
+      "coverImage": "images/48.png"
+    },
+    {
+      "id": 47,
+      "slug": "prompt-47",
+      "title": "无声电影场景",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1925469185288572953"
+      },
+      "images": [
+        "images/47.png"
+      ],
+      "prompts": [
+        "[SUBJECT] depicted in a Sepia-Toned Silent Film Scene, evoking the drama and expression of early cinema. Use muted [COLOR1] and [COLOR2] sepia tones to enhance the nostalgic atmosphere"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "landscape"
+      ],
+      "coverImage": "images/47.png"
+    },
+    {
+      "id": 46,
+      "slug": "prompt-46",
+      "title": "简单的输入中构思和创建有影响力的图像",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1925397022011527192"
+      },
+      "images": [
+        "images/46.jpeg"
+      ],
+      "prompts": [
+        "Create a surrealistic image about diabetes that conveys the message in a powerful and influential way. Plan and prepare the visual concept and prompt, then generate the image as a photograph with a caption."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "photography"
+      ],
+      "coverImage": "images/46.jpeg"
+    },
+    {
+      "id": 45,
+      "slug": "prompt-45",
+      "title": "复古锡玩具立体模型风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1920423915211375060"
+      },
+      "images": [
+        "images/45.jpeg"
+      ],
+      "prompts": [
+        "transform it into part of a miniature mechanical scene from the 1940s or ’50s, featuring:\n\n➕Shiny enamel-painted metal characters and objects.\n➕Riveted details and visible joints.\n➕Illustrated cardboard backdrops with vintage charm.\n➕Wind-up toy-style settings with gears and wheels."
+      ],
+      "examples": [],
+      "notes": [
+        "上传一张图片"
+      ],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "character",
+        "retro",
+        "toy",
+        "vehicle"
+      ],
+      "coverImage": "images/45.jpeg"
+    },
+    {
+      "id": 44,
+      "slug": "prompt-44",
+      "title": "附魔粒子泛光",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1925069047948849443"
+      },
+      "images": [
+        "images/44.png"
+      ],
+      "prompts": [
+        "[SUBJECT] surrounded by an Enchanted Particle Bloom, with particles resembling magical flower petals or leaves. Employ soft, enchanting hues of [COLOR1] and [COLOR2] to create a sense of natural magic."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/44.png"
+    },
+    {
+      "id": 43,
+      "slug": "prompt-43",
+      "title": "Airbnb风格的图标",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1924665909073084507"
+      },
+      "images": [
+        "images/43.jpeg"
+      ],
+      "prompts": [
+        "generate[concept] icon with this json style:\n{\n    \"icon_style\": {\n        \"perspective\": \"isometric\",\n        \"geometry\": {\n            \"proportions\": \"1:1 ratio canvas, with objects fitting comfortably within margins\",\n            \"element_arrangement\": \"central dominant object, with supporting elements symmetrically or diagonally placed\"\n        },\n        \"composition\": {\n            \"element_count\": \"2–4 main objects\",\n            \"spatial_depth\": \"layered to create sense of dimension and slight elevation\",\n            \"scale_consistency\": \"uniform object scale across icon set\",\n            \"scene_density\": \"minimal to moderate, maintaining clarity and visual focus\"\n        },\n        \"lighting\": {\n            \"type\": \"soft ambient light\",\n            \"light_source\": \"subtle top-right or front-top direction\",\n            \"shadow\": \"gentle drop shadows below and behind objects\",\n            \"highlighting\": \"mild edge illumination to define forms\"\n        },\n        \"textures\": {\n            \"material_finish\": \"semi-matte to satin surfaces\",\n            \"surface_treatment\": \"smooth with light tactile variation (e.g., wood grain, soft textures)\",\n            \"texture_realism\": \"stylized naturalism without hyper-realistic noise\"\n        },\n        \"render_quality\": {\n            \"resolution\": \"high-resolution octane 3D rendering\",\n            \"edge_definition\": \"crisp, no outlines; separation achieved via lighting and depth\",\n            \"visual_clarity\": \"clean, readable shapes with minimal clutter\"\n        },\n        \"color_palette\": {\n            \"tone\": \"naturalistic with slight saturation boost\",\n            \"range\": \"harmonious muted tones with gentle contrast\",\n            \"usage\": \"distinct colors per object to improve identification and readability\"\n        },\n        \"background\": {\n            \"color\": \"#FFFFFF\",\n            \"style\": \"pure white, flat\",\n            \"texture\": \"none\"\n        },\n        \"stylistic_tone\": \"premium, friendly, clean with lifestyle or service-oriented appeal\",\n        \"icon_behavior\": {\n            \"branding_alignment\": \"neutral enough for broad applications\",\n            \"scalability\": \"legible at small and medium sizes\",\n            \"interchangeability\": \"part of a cohesive icon system with interchangeable subject matter\"\n        }\n    }\n}"
+      ],
+      "examples": [],
+      "notes": [
+        "[concept]替换为：Luxuries、Gym、Marketing、Fashion等等"
+      ],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "fashion",
+        "minimalist"
+      ],
+      "coverImage": "images/43.jpeg"
+    },
+    {
+      "id": 42,
+      "slug": "prompt-42",
+      "title": "Logo超写实微型摄影",
+      "source": {
+        "name": "@alex_prompter",
+        "url": "https://x.com/alex_prompter/status/1923036265013801025"
+      },
+      "images": [
+        "images/42.jpeg"
+      ],
+      "prompts": [
+        "Recreate this [BRAND NAME] logo follow the JSON aesthetic below: \n{\n    \"style\": \"hyperrealistic miniature photography\",\n    \"scene\": {\n        \"main_subject\": \"uploaded logo scaled to appear as a large physical object\",\n        \"interaction\": \"tiny human figures interacting with the logo\",\n        \"activities\": [\n            \"cleaning the logo\",\n            \"painting parts of the logo\",\n            \"climbing ladders on the logo surface\",\n            \"taking photographs of the logo\"\n        ],\n        \"environment\": \"studio-style white background to focus on details\",\n        \"perspective\": \"frontal view with shallow depth of field for macro effect\"\n    },\n    \"logo_handling\": {\n        \"preserve_original_logo_shape\": true,\n        \"preserve_original_logo_colors\": true,\n        \"preserve_text_in_logo\": true,\n        \"use_logo_as_structural_object\": true,\n        \"adapt_logo_to_3D_surface\": true\n    },\n    \"miniature_elements\": {\n        \"figure_scale\": \"1:50 ratio to logo\",\n        \"figure_details\": \"tiny realistic humans with props like brushes, ropes, and scaffolding\",\n        \"interaction_type\": \"physical interaction, not illustration or overlay\"\n    },\n    \"lighting\": {\n        \"key_light\": \"soft diffused white light from above\",\n        \"fill_light\": \"mild side fill to reveal depth and volume\",\n        \"shadows\": \"realistic and subtle around base and figures\"\n    },\n    \"camera\": {\n        \"focus_mode\": \"macro with shallow depth of field\",\n        \"angle\": \"slightly top-down to give sense of scale\",\n        \"background\": \"clean white surface, no gradient, no transparency\"\n    },\n    \"post_processing\": {\n        \"realism_enhancement\": \"preserve logo clarity, crisp text, no artistic blurring\",\n        \"forbid_artistic_filters\": true,\n        \"forbid_color_modifications\": true\n    },\n    \"image_constraints\": {\n        \"transparent_background\": false,\n        \"include_text\": true,\n        \"adapt_to_uploaded_logo\": true,\n        \"obey_logo_shape\": true,\n        \"preserve_original_logo_colors\": true\n    },\n    \"notes\": \"The uploaded logo must be clearly recognizable, unmodified, and serve as the core structural element of the scene. Tiny people should interact with the logo realistically, as if it were a large 3D object in a physical miniature world.\"\n}"
+      ],
+      "examples": [],
+      "notes": [
+        "需上传一张Logo/图片"
+      ],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "illustration",
+        "landscape",
+        "logo",
+        "photography"
+      ],
+      "coverImage": "images/42.jpeg"
+    },
+    {
+      "id": 41,
+      "slug": "prompt-41",
+      "title": "卡通角色转换成超写实人类",
+      "source": {
+        "name": "@The_Real_Bersek",
+        "url": "https://x.com/The_Real_Bersek/status/1917174101627617752"
+      },
+      "images": [
+        "images/41.jpeg"
+      ],
+      "prompts": [
+        "Transform the cartoon character from the reference image into a hyper-realistic human while maintaining their core attributes (clothing, hairstyle, facial expression, accessories, and proportions, age and so on). Create a photorealistic portrait"
+      ],
+      "examples": [],
+      "notes": [
+        "需上传一张卡通图片"
+      ],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "photography",
+        "portrait",
+        "vehicle"
+      ],
+      "coverImage": "images/41.jpeg"
+    },
+    {
+      "id": 40,
+      "slug": "prompt-40",
+      "title": "品牌领导骑行",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1924527136657834468"
+      },
+      "images": [
+        "images/40.jpeg"
+      ],
+      "prompts": [
+        "A cinematic 1:1 scene featuring the iconic leader of [Brand Name] riding a futuristic electric motorcycle that reflects the brand’s identity. He wears a high-detail black or brand-colored carbon fiber leather jacket, with the [Brand Name] logo embroidered boldly on the chest and"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "futuristic",
+        "vehicle"
+      ],
+      "coverImage": "images/40.jpeg"
+    },
+    {
+      "id": 39,
+      "slug": "prompt-39",
+      "title": "网络矩阵梦境",
+      "source": {
+        "name": "@LudovicCreator",
+        "url": "https://x.com/LudovicCreator/status/1924382022002250151"
+      },
+      "images": [
+        "images/39.png",
+        "images/39-2.jpeg"
+      ],
+      "prompts": [
+        "[SUBJECT] reinterpreted through Cyber Matrix Dreamscapes, where cascading streams of digital code form the immersive backdrop. Imbue the scene with radical neon [COLOR1] and luminous [COLOR2] accents to evoke a futuristic reality where art converges with algorithm"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "neon",
+        "sci-fi"
+      ],
+      "coverImage": "images/39.png"
+    },
+    {
+      "id": 38,
+      "slug": "prompt-38",
+      "title": "捷克木偶风格",
+      "source": {
+        "name": "@AllaAisling",
+        "url": "https://x.com/AllaAisling/status/1924231647894896732"
+      },
+      "images": [
+        "images/38.png",
+        "images/38-2.jpeg"
+      ],
+      "prompts": [
+        "Hand-Carved Wooden Puppet (Czech Marionette Style)\n\nA hand-carved wooden marionette interpretation of [SUBJECT], with jointed limbs, painted details, and a slightly eerie antique finish. Showcase theatrical posture, stage lighting, and cultural craftsmanship in the styling."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "vehicle"
+      ],
+      "coverImage": "images/38.png"
+    },
+    {
+      "id": 37,
+      "slug": "prompt-37",
+      "title": "Logo放进我的世界中",
+      "source": {
+        "name": "@alex_prompter",
+        "url": "https://x.com/alex_prompter/status/1924503062325989836"
+      },
+      "images": [
+        "images/37.jpeg"
+      ],
+      "prompts": [
+        "Recreate the [BRAND NAME] logo following the JSON Aesthetic below: {\n\"style\": \"Minecraft-style voxel 3D rendering\",\n\"logo_handling\": {\n\"adapt_to_uploaded_logo\": true,\n\"rebuild_logo_using_voxel_blocks\": true,\n\"use_original_logo_as_strict_pixel-color map\": true,\n\"preserve_text_in_logo\": true,\n\"preserve_text_case\": true,\n\"preserve_original_logo_colors\": true,\n\"preserve_shape_and_layout\": true\n\"aspect_ratio\": [INSERT ASPECT RATIO]\n},\n\"minecraft_conversion\": {\n\"voxel_depth\": \"medium thickness to show 3D volume\",\n\"block_style\": \"authentic Minecraft texture mapping\",\n\"color_strategy\": \"each block in the logo must match a pixel from the uploaded logo exactly — no estimation or stylistic substitution\",\n\"voxel_material_match\": \"map logo pixels to Minecraft block colors that visually match pixel color as closely as possible — no creative enhancements\",\n\"disable_palette_expansion\": true\n},\n\"scene_environment\": {\n\"base\": \"neutral terrain (gray concrete or light stone)\",\n\"background\": \"simple sky (clouds, no sun flare)\",\n\"optional_elements\": [\n\"Minecraft animals at a distance\",\n\"terrain vegetation in background only\"\n],\n\"environment_color_policy\": \"environment must not share colors used in the logo to prevent blending or confusion\"\n},\n\"lighting\": {\n\"neutral directional light\": true,\n\"do_not_adjust_logo_colors_for_lighting\": true,\n\"prevent_ambient_light_color_bleed\": true\n},\n\"camera\": {\n\"angle\": \"slightly top-down with 3D logo centered\",\n\"focus\": \"sharp focus on voxel logo only, environment softly rendered\"\n},\n\"render_quality\": {\n\"voxel_texture_resolution\": \"high\",\n\"shadows\": \"natural voxel-style ambient shadows only\",\n\"disable_artistic_effects\": true\n},\n\"post_processing\": {\n\"no glow effects\": true,\n\"no color correction\": true,\n\"disable AI reinterpretation of tones or palette\": true\n},\n\"image_constraints\": {\n\"transparent_background\": false,\n\"include_text\": true,\n\"preserve_text_case\": true,\n\"preserve_original_logo_colors\": true,\n\"obey_uploaded_logo_shape\": true,\n\"match_uploaded_logo_layout\": true,\n\"enforce_color_source_from_logo_only\": true\n},\n\"notes\": \"Rebuild the uploaded logo using Minecraft-style voxel blocks. Every block must represent one pixel from the logo's original image. No creative license is allowed in color, shape, or layout. The environment is decorative only and must not affect logo readability or color perception. The final image should appear as if the logo were physically constructed in a Minecraft world using blocks that match its exact colors and shapes.\"\n}"
+      ],
+      "examples": [],
+      "notes": [
+        "需要上传Logo图，记得填写[BRAND NAME]和[INSERT ASPECT RATIO]变量，品牌名称和宽高比。"
+      ],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "branding",
+        "gaming",
+        "landscape",
+        "logo",
+        "pixel"
+      ],
+      "coverImage": "images/37.jpeg"
+    },
+    {
+      "id": 36,
+      "slug": "prompt-36",
+      "title": "马赛克壁画",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1924405701985853714"
+      },
+      "images": [
+        "images/36.png"
+      ],
+      "prompts": [
+        "A mosaic mural of a [subject], crafted from chipped ceramic and glass shards in sun-faded [color1] and weathered [color2]. Set into a cracked plaster wall, the irregular shapes and grout lines add a rustic, timeworn charm."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/36.png"
+    },
+    {
+      "id": 35,
+      "slug": "prompt-35",
+      "title": "人物戏剧夸张风格",
+      "source": {
+        "name": "@dotey",
+        "url": "https://x.com/dotey/status/1924288320881750108"
+      },
+      "images": [
+        "images/35.png",
+        "images/35-2.jpeg"
+      ],
+      "prompts": [
+        "A high-resolution vertical Pixar-style 3D character illustration.\n\nMain character:  \nSalvador Dalí — depicted as a tall, slim, and slightly exaggerated Pixar-style 3D character.  \nWearing a classic blue shirt, yellow tie, high-waisted plaid trousers with suspenders, and leather shoes.  \nHis iconic long upturned mustache, slick black hair, sharply arched eyebrows, and slightly eccentric posture.  \nStands with chest out, one hand on hip, head tilted slightly back in his typical theatrical flair.\n\nBackground:  \nFlat, clean yellow background with subtle surface texture.  \nStrong sunlight from top-left casts a distinct and enlarged shadow on the wall behind him.\n\nKey Concept – Shadow as spiritual projection:  \nThe shadow cast behind him does **not** mirror his body shape.  \nInstead, it takes the form of one of his most iconic artworks —  \na surreal melted clock with long dripping arms, inspired by “The Persistence of Memory”.\n\nThe melted clock shadow is positioned diagonally, starting from his shoulder,  \nstretching wide and low across the yellow wall, surreal and fluid, yet unmistakably symbolic.\n\nThis shadow is **Dalí’s legacy made visible** — a symbolic extension of his identity through time, dream, and visual distortion.\n\nLighting & Rendering:  \nPixar-like rendering with detailed but stylized textures.  \nUse subtle filmic grain, soft shadows, and warm color grading.  \nSubtle sparkles or light speckles inside the shadow to evoke dreamlike texture.\n\nTypography (top-left corner):  \n“Salvador Dalí” in minimalist black sans-serif font, “Dalí” bolded."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "character",
+        "illustration",
+        "minimalist",
+        "portrait",
+        "typography"
+      ],
+      "coverImage": "images/35.png"
+    },
+    {
+      "id": 34,
+      "slug": "prompt-34",
+      "title": "云的艺术",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1924473546216292441"
+      },
+      "images": [
+        "images/34.jpeg"
+      ],
+      "prompts": [
+        "A photograph captures a daytime scene with a [SUBJECT/OBJECT] formed by scattered clouds in the sky, positioned above a [LOCATION]"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "photography"
+      ],
+      "coverImage": "images/34.jpeg"
+    },
+    {
+      "id": 33,
+      "slug": "prompt-33",
+      "title": "复古像素UI图标",
+      "source": {
+        "name": "@egeberkina",
+        "url": "https://x.com/egeberkina/status/1924462051474174222"
+      },
+      "images": [
+        "images/33.png"
+      ],
+      "prompts": [
+        "retexture the image attached in the following json aesthetic style:\n{\n  \"style\": \"Retro Pixel UI Icons\",\n  \"resolution\": \"low (32x32 or 48x48)\",\n  \"color_palette\": [\n    \"#F2F2F2\",  \n    \"#C0C0C0\",  \n    \"#000000\", \n    \"#FFFFFF\",  \n    \"#0000FF\",  \n    \"#00FF00\",  \n    \"#FFFF99\",  \n    \"#008080\" \n  ],\n  \"outline\": {\n    \"enabled\": true,\n    \"color\": \"#000000\",\n    \"thickness\": \"1px\"\n  },\n  \"shading\": {\n    \"method\": \"dithering\",\n    \"colors_used\": [\"base color\", \"highlight\", \"shadow\"],\n    \"pattern\": \"checkerboard or diagonal lines\"\n  },\n  \"lighting\": {\n    \"type\": \"flat\",\n    \"source\": \"top-left\",\n    \"highlight_color\": \"#FFFFFF\",\n    \"shadow_color\": \"#808080\"\n  },\n  \"background\": {\n    \"color\": \"#F2F2F2\",\n    \"type\": \"plain\",\n    \"transparency\": false\n  },\n  \"object_properties\": {\n    \"style\": \"pixel art\",\n    \"perspective\": \"isometric or front-facing\",\n    \"animation\": {\n      \"enabled\": false,\n      \"frame_style\": \"static pixel art\"\n    }\n  }\n}"
+      ],
+      "examples": [],
+      "notes": [
+        "需要上传一个参考图"
+      ],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "pixel",
+        "retro",
+        "ui"
+      ],
+      "coverImage": "images/33.png"
+    },
+    {
+      "id": 32,
+      "slug": "prompt-32",
+      "title": "卡通风格文本标志",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1924466922545877098"
+      },
+      "images": [
+        "images/32.png"
+      ],
+      "prompts": [
+        "Create a bold, warped cartoon-style text design with two distinct layers. The top layer should say “SUPER GNARLY” in warped bubble letters with a melty, drippy texture, like ghost slime or goo. The letters should feel heavy and organic, with a slightly psychedelic or paranormal vibe. The bottom layer should say “SOCIETY” in much smaller, script-like or handwritten-style letters that tuck underneath or nestle between the larger title letters. Both layers should be solid white with thick black outlines. No gradients, shading, or texture. Layout should be playful and a little chaotic, but still readable. Vector friendly. Blue background. Square aspect ratio."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "logo",
+        "vehicle"
+      ],
+      "coverImage": "images/32.png"
+    },
+    {
+      "id": 31,
+      "slug": "prompt-31",
+      "title": "超写实拼图肖像",
+      "source": {
+        "name": "@ZHO_ZHO_ZHO",
+        "url": "https://x.com/ZHO_ZHO_ZHO/status/1923999321634283862"
+      },
+      "images": [
+        "images/31.jpeg"
+      ],
+      "prompts": [
+        "高分辨率的摄影棚人像，一位惊艳年轻模特「安妮海瑟薇」为主角。她拥有一头顺直的黑发，背景为白色，无任何可辨识的元素。她的脸略微侧转，但目光直视镜头，目光强烈而专注，毫无动摇。\n\n她整张脸由拼图块组成——每一块都清晰可见，边缘整齐，具备细腻的立体感。她轻柔地用手指捏着一块刚从脸颊取下的拼图块，露出其下方一个空洞的黑色虚空。\n\n光线集中且具方向性，几乎不产生阴影，但准确地勾勒出皮肤的轮廓与拼图结构的立体感。整体氛围超现实、精准且高度写实。\n\n顶部有像时尚杂志一样的标题“ZHOGUE”（在人物后面）"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "photography",
+        "portrait"
+      ],
+      "coverImage": "images/31.jpeg"
+    },
+    {
+      "id": 30,
+      "slug": "prompt-30",
+      "title": "公司金币",
+      "source": {
+        "name": "@umesh_ai",
+        "url": "https://x.com/umesh_ai/status/1924526898840822207"
+      },
+      "images": [
+        "images/30.jpeg"
+      ],
+      "prompts": [
+        "Prompt: A high-resolution photograph of a gold coin featuring the [COMPANY NAME] logo at the center. The coin should have the year [YEAR] engraved at the top. Include finely detailed engravings, ornamental border patterns, and authentic coin textures like reeded edges, matte"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "photography"
+      ],
+      "coverImage": "images/30.jpeg"
+    },
+    {
+      "id": 29,
+      "slug": "prompt-29",
+      "title": "面包形态",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1924479430157812140"
+      },
+      "images": [
+        "images/29.png"
+      ],
+      "prompts": [
+        "A highly realistic sculpture of a [object], made entirely from [bread type] with ultra-detailed texture and color. The surface shows the natural properties of the bread, golden-brown, glossy, flaky or crusty, with visible layers or seeds where appropriate, studio lighting, soft"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "sculpture"
+      ],
+      "coverImage": "images/29.png"
+    },
+    {
+      "id": 28,
+      "slug": "prompt-28",
+      "title": "狭窄走廊里奔跑",
+      "source": {
+        "name": "@B_4AI",
+        "url": "https://x.com/B_4AI/status/1924410511392719343"
+      },
+      "images": [
+        "images/28.png"
+      ],
+      "prompts": [
+        "A thrilling 3D cartoon scene: [CHARACTER1] runs through a narrow corridor inside [Place], chased at high speed by [CHARACTER2]. Their facial expressions reflect tension and focus, with beads of sweat glistening under dramatic lighting."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "character",
+        "vehicle"
+      ],
+      "coverImage": "images/28.png"
+    },
+    {
+      "id": 27,
+      "slug": "prompt-27",
+      "title": "品牌奢华之物从天而降",
+      "source": {
+        "name": "@hc_dsn",
+        "url": "https://x.com/hc_dsn/status/1924390055231287650"
+      },
+      "images": [
+        "images/27.png"
+      ],
+      "prompts": [
+        "Create a image with 1:1 ratio\na dreamy brand ad of [Brand], a brand designed bubble-like capsule with brand color parachute packaging their classic product, against blue sky and other blurry parachute packaging, white cloud, a small brand logo on top, a tiny slogan beneath it, cinematic day lighting, lens flare, dof, hdr"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "product"
+      ],
+      "coverImage": "images/27.png"
+    },
+    {
+      "id": 26,
+      "slug": "prompt-26",
+      "title": "水流身份",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1924325011847884979"
+      },
+      "images": [
+        "images/26.jpeg"
+      ],
+      "prompts": [
+        "An ultra-high resolution 8K cinematic render of the [Brand Name] logo, sculpted entirely from flowing crystal-clear water. The liquid forms every curve and edge of the brand’s logo with fluid precision, highlighted by vibrant neon accents inspired by [Brand Name]’s color identity. The background is pitch black, creating sharp contrast and drama. The lighting is dynamic, revealing sharp reflections, glowing edges, and the motion of water as it ripples and splashes. Droplets, shine, and soft glass-like textures give the logo a surreal, luxurious, and futuristic appearance — poster-quality, 1:1 format."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "futuristic",
+        "neon",
+        "poster"
+      ],
+      "coverImage": "images/26.jpeg"
+    },
+    {
+      "id": 25,
+      "slug": "prompt-25",
+      "title": "按键删除周一",
+      "source": {
+        "name": "@michaelrabone",
+        "url": "https://x.com/michaelrabone/status/1924374502529438005"
+      },
+      "images": [
+        "images/25.jpeg"
+      ],
+      "prompts": [
+        "Detailed photographic image of a miniature person in bed feeling cranky under an opened 'Delete Monday' keyboard keycap, using the inside of the keycap as a mini bedroom complete with the usual bedroom stuff"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "interior",
+        "photography"
+      ],
+      "coverImage": "images/25.jpeg"
+    },
+    {
+      "id": 24,
+      "slug": "prompt-24",
+      "title": "新市场中的美妆品牌",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1924439540028313693"
+      },
+      "images": [
+        "images/24.png",
+        "images/24-2.jpeg"
+      ],
+      "prompts": [
+        "A product photography shot of a [PRODUCT] inspired by [FOOD BRAND], placed against a soft light gray background. The product is sharply focused with soft studio lighting. The packaging design includes the official [FOOD BRAND] logo and reflects the brand’s colors and style. The product is sleek, glossy, and realistic, with high detail and elegant presentation. No food items, just the makeup product. Include only the makeup item in the shot. Modern aesthetic, luxury cosmetic branding"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "food",
+        "photography",
+        "product"
+      ],
+      "coverImage": "images/24.png"
+    },
+    {
+      "id": 23,
+      "slug": "prompt-23",
+      "title": "平面设计等边风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1924388407939076377"
+      },
+      "images": [
+        "images/23.png"
+      ],
+      "prompts": [
+        "A flat isometric digital illustration of [describe the subject: e.g., a modern workspace, a city block, a group of app icons, a sports shop], clean lines and geometric forms, bright pastel colors, simplified perspective with 3D depth, minimal shading, white background or light gradient. Style resembles modern vector infographics, ideal for UI, app design or web visuals."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "infographic",
+        "minimalist",
+        "ui"
+      ],
+      "coverImage": "images/23.png"
+    },
+    {
+      "id": 22,
+      "slug": "prompt-22",
+      "title": "自定义气球",
+      "source": {
+        "name": "@ZHO_ZHO_ZHO",
+        "url": "https://x.com/ZHO_ZHO_ZHO/status/1924121078559125841"
+      },
+      "images": [
+        "images/22.jpeg"
+      ],
+      "prompts": [
+        "一件高度写实的 3D 装置艺术：字母 Z 被设计成充气球囊造型，整体形态如同流畅弯曲的“Z”字路径，由两段斜线和一个折角构成，边缘略微卷翘，充满柔软的气压感。\n\n视角为正面稍仰视角（约10°）的正交投影，主体置于画面正中央，占据几乎全部画幅，背景为纯黑色，形成类似剧院聚光灯的聚焦舞台效果。\n\n材质为高弹性亮面 PVC，表面涂有高光清漆。主色为柔亮粉色（#FF96AC），阴影部分渐变为淡紫粉色，表面同时具备镜面高光和柔和漫反射，呈现丝滑、饱满、有张力的视觉质感。\n\n左下角可见一个金属螺旋气嘴（银灰色），尺寸很小但极具真实感，暗示其为充气物体。右下笔画末端印有一串黑色的警示文字和安全图标，以“ZHOGUE”风格排版，呼应充气玩具视觉语言。\n\n主光源来自左上方约 35°，呈现清晰的硬边聚光灯效果：在顶部折角与中央斜线区域形成椭圆形白色高光，内折阴影区带有柔和的粉紫色内反射。\n\n辅光来自右后方，轻柔描边顶部和转折边缘，使形体与黑背景分离，整体光比约为 1:2，保持色彩通透与立体感。亮区色温偏冷，营造冷暖对比，进一步突显质感。\n\n球囊表面略显鼓胀，折角与转折区域有尖锐的折痕，带来软体与几何的视觉张力。最深的转折处投下细长阴影，仿佛即将破裂；下方末端则有轻微拉扯感，如气球尾部即将被牵动。\n\n整体概念融合了字母结构与充气玩具的材质语言，通过夸张体积、真实光感与极简舞台感构建出“字母也能呼吸”的视觉冲击，呈现理性几何与感性触觉的碰撞。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "3d",
+        "minimalist",
+        "toy",
+        "typography"
+      ],
+      "coverImage": "images/22.jpeg"
+    },
+    {
+      "id": 21,
+      "slug": "prompt-21",
+      "title": "产品变成纸玻璃",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1923449494898618849"
+      },
+      "images": [
+        "images/21.jpeg"
+      ],
+      "prompts": [
+        "[Product by Brand] in a surreal, minimalist paper-glass style advertisement.\nThe product is centered, crafted from translucent frosted glass-paper, placed against a clean white or softly tinted background.\nSoft cinematic lighting creates gentle contrast and ambient shadows.\nA single brand color subtly interacts with the scene through glow, mist, liquid, or foam.\nInclude a bold, elegant 4-word slogan near the product.\nThe brand logo appears subtly etched, glowing, or printed in a refined manner.\nVertical or square aspect ratio, ultra-detailed, poster-quality, visually soothing and conceptually refined."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "minimalist",
+        "paper-craft",
+        "poster",
+        "product"
+      ],
+      "coverImage": "images/21.jpeg"
+    },
+    {
+      "id": 20,
+      "slug": "prompt-20",
+      "title": "透明塑料袋装物体",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1923376928918327386"
+      },
+      "images": [
+        "images/20.jpeg"
+      ],
+      "prompts": [
+        "A high-resolution photograph of a clear plastic drawstring bag placed on a light gray background. Inside the bag are multiple tiny 3D [subject] figures arranged neatly. The bag is tied with a soft white ribbon and has a black label tag that reads ‘[LABEL TEXT]’. Soft lighting and clean shadows emphasize the realistic textures and details"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "photography"
+      ],
+      "coverImage": "images/20.jpeg"
+    },
+    {
+      "id": 19,
+      "slug": "prompt-19",
+      "title": "Emoji变成一个花盆",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1923739813414568075"
+      },
+      "images": [
+        "images/19.png"
+      ],
+      "prompts": [
+        "A high-quality photo of a cute ceramic [object/animal]-shaped planter with a glossy finish, filled with a variety of vibrant succulents and greenery including a spiky Haworthia, a rosette-shaped Echeveria, and delicate white flowers. The planter has a friendly face and sits on a soft, neutral background with diffused natural lighting, showcasing fine textures and color contrast in a clean, minimalistic composition"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "emoji",
+        "minimalist",
+        "nature",
+        "photography"
+      ],
+      "coverImage": "images/19.png"
+    },
+    {
+      "id": 18,
+      "slug": "prompt-18",
+      "title": "品牌我的世界风格",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1923757741262164427"
+      },
+      "images": [
+        "images/18.png",
+        "images/18-2.jpeg"
+      ],
+      "prompts": [
+        "\"A Minecraft-style voxel recreation of a [BRAND NAME] [OBJECT], built entirely from pixelated cubes — detailed voxel modeling, signature brand colors and logo, blocky textures, clean lighting, stylized yet recognizable, 3D render, high resolution, playful and creative interpretation"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "gaming",
+        "nature",
+        "pixel"
+      ],
+      "coverImage": "images/18.png"
+    },
+    {
+      "id": 17,
+      "slug": "prompt-17",
+      "title": "未来一瞥",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1921900687689941197"
+      },
+      "images": [
+        "images/17.png"
+      ],
+      "prompts": [
+        "A cinematic rendering of [subject] walking through a rain-soaked street at night, illuminated by moody neon lights, reflections dancing on wet pavement, and a hazy urban skyline in the background. The subject feels alive, caught between solitude and electricity."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "futuristic",
+        "neon"
+      ],
+      "coverImage": "images/17.png"
+    },
+    {
+      "id": 16,
+      "slug": "prompt-16",
+      "title": "品牌星球世界",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1923064017477628160"
+      },
+      "images": [
+        "images/16.png"
+      ],
+      "prompts": [
+        "Planet [Brand name], Year 3025. A distant world shaped entirely by the essence of the brand. The landscapes echo its core identity — from surreal terrains to fantastical weather patterns. Native flora and fauna embody its signature ingredients and aesthetics. Rivers flow with iconic flavors. Architecture is inspired by its packaging and visual language, fused with futuristic technology. The atmosphere is rich in texture, cinematic lighting, and surreal detail. A dreamlike vision of brand identity reimagined as a sci-fi utopia."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "branding",
+        "futuristic",
+        "landscape",
+        "nature",
+        "product",
+        "sci-fi"
+      ],
+      "coverImage": "images/16.png"
+    },
+    {
+      "id": 15,
+      "slug": "prompt-15",
+      "title": "树屋",
+      "source": {
+        "name": "@TheRelianceAI",
+        "url": "https://x.com/TheRelianceAI/status/1923451797869371701"
+      },
+      "images": [
+        "images/15.png"
+      ],
+      "prompts": [
+        "A quiet morning in a luxury treehouse retreat created by [BRAND NAME] — golden light pours through windows framed in the brand’s signature colors. A cozy seating area features playful, thematic furniture, and a circular rug inspired by [BRAND SYMBOL OR PRODUCT]. The coffee table bears the embossed logo, while a screen on the wall loops the phrase: “[BRAND SLOGAN].” A curated display of iconic items adds a sense of nostalgia. Subtle ambient lighting glows in brand tones, and a tray with signature treats sits near the window. It’s cozy, imaginative, and unmistakably [BRAND NAME]"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "nature",
+        "product"
+      ],
+      "coverImage": "images/15.png"
+    },
+    {
+      "id": 14,
+      "slug": "prompt-14",
+      "title": "创意广告",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1924090458298609881"
+      },
+      "images": [
+        "images/14.png"
+      ],
+      "prompts": [
+        "A high-impact advertisement set against a clean, dark or high-contrast background. A [product] is centered, sharply lit and highly detailed. Around it, surreal, stylized visual [elements] illustrations explode outward (e.g., musicians, runners, curls, sunbursts), vibrant color palette, neon. bold uppercase ad copy at the top that reads [TEXT] and the brand logo at the bottom, modern Ad"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "illustration",
+        "neon",
+        "product"
+      ],
+      "coverImage": "images/14.png"
+    },
+    {
+      "id": 13,
+      "slug": "prompt-13",
+      "title": "创意广告",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1923980304525537424"
+      },
+      "images": [
+        "images/13.png"
+      ],
+      "prompts": [
+        "Use the uploaded product image exactly as it is — do not alter, redraw, or reinterpret any part of it. Follow the guidelines below to create a high-quality, cinematic product presentation:\n\n• Keep the product fully intact — all text, labels, proportions, packaging, and colors must remain exactly the same.\n• Use natural or cinematic lighting to enhance the product’s appeal.\n• Place the product on a realistic surface that matches its category (e.g. wooden kitchen table for bread, bathroom shelf for skincare, desk for tech gadgets).\n• Add complementary props if appropriate (e.g. toast and coffee for bread, leaves and water droplets for skincare) — but do not let them touch or cover the product.\n• Use a softly blurred or ambient background (e.g. kitchen, morning window light, minimal interior).\n• Include soft shadows and subtle reflections for a grounded, photo-realistic effect.\n• Final result should feel premium, natural, and visually appealing — with 100% fidelity to the uploaded product image."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "food",
+        "interior",
+        "minimalist",
+        "photography",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/13.png"
+    },
+    {
+      "id": 12,
+      "slug": "prompt-12",
+      "title": "创意广告",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1923016036120658122"
+      },
+      "images": [
+        "images/12.png"
+      ],
+      "prompts": [
+        "A minimalist and creative advertisement set on a clean white background.\nA real [Real Object] is integrated into a hand-drawn black ink doodle, using loose, playful lines. The [Doodle Concept] interacts with the object in a clever, imaginative way. Include bold black [Ad Copy] text at the top or center. Place the [Brand Logo] clearly at the bottom. The visual should be clean, fun, high-contrast, and conceptually smart."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "logo",
+        "minimalist"
+      ],
+      "coverImage": "images/12.png"
+    },
+    {
+      "id": 11,
+      "slug": "prompt-11",
+      "title": "品牌之爱话术",
+      "source": {
+        "name": "@aziz4ai",
+        "url": "https://x.com/aziz4ai/status/1924046710218645932"
+      },
+      "images": [
+        "images/11.jpeg"
+      ],
+      "prompts": [
+        "A romantic square-format bouquet inspired by [Brand Name]. Roses are crafted from visual patterns or textures that reflect the brand’s identity. The bouquet is wrapped in luxurious material echoing the brand’s signature style (e.g. silk, velvet, leather), and elegantly tied with one of the brand’s iconic products, replacing a traditional ribbon. Place it on a surface that matches the brand’s aesthetic. Add a message card beside the bouquet with a short, emotional 3-word slogan representing the brand’s spirit. Include the [Brand Name] logo subtly in the scene. Cinematic lighting, ultra-detailed, elegant depth of field, premium editorial quality."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "nature",
+        "product",
+        "vehicle"
+      ],
+      "coverImage": "images/11.jpeg"
+    },
+    {
+      "id": 10,
+      "slug": "prompt-10",
+      "title": "熔化变异文本",
+      "source": {
+        "name": "@gnrlyxyz",
+        "url": "https://x.com/gnrlyxyz/status/1924102927154626885"
+      },
+      "images": [
+        "images/10.png"
+      ],
+      "prompts": [
+        "Create a psychedelic, grotesque cartoon-style text design that says “GNARLY”. Arrange the letters in a straight horizontal line. Each letter should be lumpy, melting, and oozing with bright, clashing flat colors like slime green, neon yellow, and hot pink. Each letter must be filled with only one solid flat color, with no gradients or transitions. All drips, melts, and oozes must be solid black with no shading or gradient. Make the design vector-friendly with clean, solid fills and bold black outlines. Add extra black and white eyeballs to make each letter feel like a weird mutated creature. Keep the composition chaotic but readable, like a mutant version of a Saturday morning cartoon. Black background. Square aspect ratio."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "animal",
+        "cartoon",
+        "neon",
+        "vehicle"
+      ],
+      "coverImage": "images/10.png"
+    },
+    {
+      "id": 9,
+      "slug": "prompt-9",
+      "title": "青花瓷风格",
+      "source": {
+        "name": "@firatbilal",
+        "url": "https://x.com/firatbilal/status/1923627963251052769"
+      },
+      "images": [
+        "images/9.png"
+      ],
+      "prompts": [
+        "Using the uploaded image as the exact visual base, transform it into a hyper-realistic 3D object that retains the original shape and proportions of the logo only. Apply traditional Ottoman Iznik ceramic textures—featuring a warm white glazed base with delicate crackle lines, overlaid with vivid cobalt blue, turquoise, and bold red floral motifs such as tulips, carnations, and arabesque vines. The entire logo should be treated as a standalone porcelain sculpture with raised, hand-painted detailing and no background plate or tile structure. Ensure the decorative patterns elegantly follow the contours of the Bugatti logo, without altering its form. Render the object in a pure black background with Cinema 4D-style product lighting—highlighting realistic ceramic gloss, material depth, and subtle reflections. The final result should feel like a luxurious handcrafted ceramic reinterpretation, balancing heritage ornamentation with industrial branding."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "branding",
+        "nature",
+        "product",
+        "sculpture",
+        "vehicle"
+      ],
+      "coverImage": "images/9.png"
+    },
+    {
+      "id": 8,
+      "slug": "prompt-8",
+      "title": "刺绣插图风格",
+      "source": {
+        "name": "@Artedeingenio",
+        "url": "https://x.com/Artedeingenio/status/1924032621220188340"
+      },
+      "images": [
+        "images/8.png"
+      ],
+      "prompts": [
+        "A handcrafted illustration that simulates traditional embroidery using colorful threads on linen fabric. All elements are “stitched” with visible yarn textures, using techniques like satin stitch, backstitch, and French knots. Raised contours and directional thread flow create a tactile, cozy appearance. The background is made of woven linen, with gentle pastel or folk-inspired colors. The composition is friendly and magical, evoking a storybook charm. Include decorative details such as flowers, suns, clouds, trees or symbols to enhance the folk embroidery style."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "illustration"
+      ],
+      "coverImage": "images/8.png"
+    },
+    {
+      "id": 7,
+      "slug": "prompt-7",
+      "title": "刺绣肖像",
+      "source": {
+        "name": "@azed_ai",
+        "url": "https://x.com/azed_ai/status/1924042329700372929"
+      },
+      "images": [
+        "images/7.png"
+      ],
+      "prompts": [
+        "An embroidered portrait of [subject], [colors] thread on deep linen fabric. Visible needlework, layered textures, and handmade patterns give it an earthy, sacred feel.",
+        "An embroidered portrait of Elon Musk, stitched with rich steel grey and electric blue thread on deep linen fabric. Visible needlework, layered textures, and handmade patterns give it an earthy, sacred feel."
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "*注意：可替换提示词中的 `[subject]`和`[colors]` 为具体主题和颜色，例如 \"Elon Musk\", \"stitched with rich steel grey and electric blue\" 等。*",
+      "tags": [
+        "portrait"
+      ],
+      "coverImage": "images/7.png"
+    },
+    {
+      "id": 6,
+      "slug": "prompt-6",
+      "title": "金色抽象综合风格",
+      "source": {
+        "name": "@firatbilal",
+        "url": "https://x.com/firatbilal/status/1924130071758962938"
+      },
+      "images": [
+        "images/6.png"
+      ],
+      "prompts": [
+        "{\n    \"base_image\": \"uploaded image\",\n    \"style_transfer\": {\n        \"visual_characteristics\": {\n            \"head_and_face\": {\n                \"material\": \"translucent resin with embedded starlight and glowing neural circuits\",\n                \"surface_effect\": \"mirror-gloss with gold filament veins and galaxy-like reflections\",\n                \"lighting\": \"dynamic cinematic rim lights with volumetric glow\"\n            },\n            \"body_structure\": {\n                \"texture\": \"high-polish white ceramic with embedded gold wiring\",\n                \"design\": \"futuristic like organic plating\",\n                \"highlight_elements\": \"subtle internal light flows mimicking synaptic energy\"\n            },\n            \"motion_effect\": {\n                \"visual_glitch\": \"subtle horizontal motion blur on head edges\",\n                \"energy_flow\": \"faint pulsing particle lights across body\"\n            },\n            \"background\": {\n                \"type\": \"neutral gradient or dark void\",\n                \"focus\": \"emphasize figure's luminous contrast\"\n            }\n        },\n        \"application_target\": \"Replace surface and material style of uploaded image with the characteristics described above, while preserving the original pose, structure, and composition of the target image.\"\n    }\n}"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "character",
+        "futuristic"
+      ],
+      "coverImage": "images/6.png"
+    },
+    {
+      "id": 5,
+      "slug": "prompt-5",
+      "title": "创建你自己的GTA角色",
+      "source": {
+        "name": "@Anima_Labs",
+        "url": "https://x.com/Anima_Labs/status/1924135446629728712"
+      },
+      "images": [
+        "images/5.png"
+      ],
+      "prompts": [
+        "Act as a creative director at Rockstar Games. Create a fictional GTA VI character sheet in the exact same style as the official GTA VI promotional images.\n\nThe layout must be:\n\nA horizontal character sheet, with the character on the right, in a dynamic pose that reflects their personality.\nOn the left, include the following structured text:\nA small \"VI\" logo at the top left (mention it visually).\nThe character’s name in big bold text.\nA catchy slogan or tagline right below in a different bright color.\nA short backstory (3–5 lines) written in an ironic, street-smart, or playful tone — just like Rockstar’s tone of voice.\n\nUse the vibrant Vice City aesthetic with sunset lighting, neon accents, and cel-shaded comic style. The character’s clothing, action, and environment must reflect their archetype and background.\n\nLet me customize the following variables:\n\nArchetype: {your choice}\n\nGender: {your choice}\n\nSkin tone: {your choice}\n\nHairstyle: {your choice}\n\nEmotion : {your choice}\n\nOutfit: {your choice}\n\nWeapon or action: {your choice}\n\nBackground details: {your choice}\n\nGenerate a fictive name in tittle and a description in english\n\nFormat the final result like a finished in-game asset reveal. The vibe should be over-the-top, stylish, and full of personality — as if part of the real GTA VI world.\n\n(if the \"Your choice\" sections are not filled with personalized information, it's up to you to generate it randomly by yourself) generate the visual directly from now on"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "character",
+        "gaming",
+        "landscape",
+        "neon"
+      ],
+      "coverImage": "images/5.png"
+    },
+    {
+      "id": 4,
+      "slug": "prompt-4",
+      "title": "马斯克在公园画画",
+      "source": null,
+      "images": [
+        "images/musk-in-the-park.jpg"
+      ],
+      "prompts": [
+        "创作一个逼真的户外场景，其中一位日本画家正在为马斯克画画。场景中，画家坐在画架前，而马斯克则坐在对面被描绘（不带任何卡通或动漫风格）。环境应充满生机,自然且阳光明媚——比如公园或热闹的户外场所。整体风格必须完全写实，唯独画家画架上的作品例外：那应该是马斯克的吉卜力风格动漫肖像，与周围的写实环境形成强烈对比。请确保画中人物是写实风格，画上的肖像才是动漫风格。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "cartoon",
+        "landscape",
+        "nature",
+        "portrait"
+      ],
+      "coverImage": "images/musk-in-the-park.jpg"
+    },
+    {
+      "id": 3,
+      "slug": "prompt-3",
+      "title": "蜜蜂科学城",
+      "source": null,
+      "images": [
+        "images/bee-science-city.png"
+      ],
+      "prompts": [
+        "创建图像 3D Q版迷你风格，一座蜂巢结构的甜蜜科研基地，建筑由六边形透明蜂蜡舱堆叠而成，顶部悬浮滴落蜂蜜的太阳花洒水器，外墙爬满发光花粉藤蔓。侧面延伸出蜂蜡滑梯与蒲公英降落伞，入口是旋转的向日葵转门。透过蜂巢窗可见内部试管操作台、蜜糖吊灯和穿白大褂的蜜蜂博士。花园里有驾驶花粉摩托的甲虫快递员、举着放大镜的蝴蝶研究员，搭配蜂蜜长椅、雏菊花洒喷泉和动态萤火虫光标，整体笼罩琥珀色光晕，打造超现实昆虫科学城的萌趣生态。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "architecture",
+        "nature"
+      ],
+      "coverImage": "images/bee-science-city.png"
+    },
+    {
+      "id": 2,
+      "slug": "prompt-2",
+      "title": "四格漫画 (相对论)",
+      "source": null,
+      "images": [
+        "images/the-theory-of-relativity.png"
+      ],
+      "prompts": [
+        "make a colorful page of manga describing the theory of relativity. add some humor"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "creative"
+      ],
+      "coverImage": "images/the-theory-of-relativity.png"
+    },
+    {
+      "id": 1,
+      "slug": "prompt-1",
+      "title": "手绘风格的信息图卡片",
+      "source": null,
+      "images": [
+        "images/hand-drawn-style-infographic-card.png"
+      ],
+      "prompts": [
+        "创作一张手绘风格的信息图卡片，比例为9:16竖版。卡片主题鲜明，背景为带有纸质肌理的米色或米白色，整体设计体现质朴、亲切的手绘美感。 卡片上方以红黑相间、对比鲜明的大号毛笔草书字体突出标题，吸引视觉焦点。文字内容均采用中文草书，整体布局分为2至4个清晰的小节，每节以简短、精炼的中文短语表达核心要点。字体保持草书流畅的韵律感，既清晰可读又富有艺术气息。 卡片中点缀简单、有趣的手绘插画或图标，例如人物或象征符号，以增强视觉吸引力，引发读者思考与共鸣。 整体布局注意视觉平衡，预留足够的空白空间，确保画面简洁明了，易于阅读和理解。 <h1><span style=\"\"color:red\"\">「认知」</span>决定上限 <span style=\"\"color:red\"\">「圈子」</span>决定机会</h1> - 你赚不到「认知」以外的钱， - 也遇不到「圈子」以外的机会。"
+      ],
+      "examples": [],
+      "notes": [],
+      "originFile": "100.md",
+      "description": "",
+      "tags": [
+        "illustration",
+        "infographic",
+        "paper-craft",
+        "portrait",
+        "typography"
+      ],
+      "coverImage": "images/hand-drawn-style-infographic-card.png"
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>🍌Nano Banana🍌 Prompts Gallery</title>
+  <link rel="stylesheet" href="./assets/styles.css">
+</head>
+<body>
+  <header class="app-header">
+    <div class="header-top">
+      <h1>🍌Nano Banana🍌 Prompts Gallery</h1>
+      <p class="tagline">浏览、筛选和搜索 🍌 Nano Banana 🍌 图片提示词案例，快速复制提示词，探索灵感。</p>
+    </div>
+    <div class="control-bar">
+      <label class="search-field" for="searchInput">
+        <span class="search-icon" aria-hidden="true">🔍</span>
+        <input id="searchInput" type="search" placeholder="搜索案例编号、标题或提示词..." autocomplete="off">
+        <button id="clearSearch" class="ghost-btn" type="button" aria-label="清除搜索">✕</button>
+      </label>
+      <button id="clearFilters" class="ghost-btn clear-filter-btn" type="button">清除筛选</button>
+      <div id="resultStats" class="result-stats" role="status" aria-live="polite"></div>
+    </div>
+    <div id="tagFilters" class="tag-filter"></div>
+  </header>
+
+  <main>
+    <section id="gallery" class="gallery" aria-live="polite"></section>
+    <div id="emptyState" class="empty-state hidden">
+      <p>没有匹配的结果，请尝试调整标签或搜索关键词。</p>
+    </div>
+  </main>
+
+  <div id="detailModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+    <div class="modal-content">
+      <button id="modalClose" class="modal-close" aria-label="关闭详情">✕</button>
+      <header class="modal-header">
+        <h2 id="modalTitle"></h2>
+        <div id="modalSource" class="modal-source"></div>
+      </header>
+      <div class="modal-tags" id="modalTags"></div>
+      <section id="modalImages" class="modal-section"></section>
+      <section id="modalPrompts" class="modal-section"></section>
+      <section id="modalExamples" class="modal-section"></section>
+      <section id="modalNotes" class="modal-section"></section>
+      <section id="modalDescription" class="modal-section"></section>
+    </div>
+  </div>
+
+  <div id="toast" class="toast hidden" role="status" aria-live="polite"></div>
+
+  <script type="module" src="./assets/app.js"></script>
+</body>
+</html>

--- a/scripts/generate-dataset.js
+++ b/scripts/generate-dataset.js
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+
+/**
+ * Build a structured JSON dataset from the project markdown prompt collections.
+ * The script scans all "<number>.md" files, extracts prompt metadata, attaches
+ * heuristic tags, and writes the consolidated payload to data/prompts.json.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const SOURCE_DIR = ROOT;
+const OUTPUT_DIR = path.join(ROOT, 'data');
+const OUTPUT_FILE = path.join(OUTPUT_DIR, 'prompts.json');
+
+/**
+ * Utility to normalise image paths (remove leading "./").
+ */
+function normaliseImagePath(src) {
+  if (!src) return null;
+  return src.replace(/^\.\//, '');
+}
+
+/**
+ * Extract a clean text version of a markdown inline fragment that might contain
+ * emphasis markers (e.g. "**提示：内容**").
+ */
+function stripMarkdownEmphasis(text) {
+  return text.replace(/^\*\*/g, '').replace(/\*\*$/g, '').trim();
+}
+
+/**
+ * Generate tags for an entry based on title, prompts, and supplemental text.
+ * Tags are derived heuristically from keyword matches in both English and Chinese.
+ */
+function generateTags(entry) {
+  const parts = [
+    entry.title || '',
+    entry.description || '',
+    ...(entry.prompts || []),
+    ...(entry.examples || []),
+    ...(entry.notes || []),
+  ];
+  const textFull = parts.join('\n');
+  const textLower = textFull.toLowerCase();
+
+  const has = (checker) => checker(textFull, textLower);
+
+  const tagMatchers = [
+    { tag: '3d', match: (full, lower) => /3d|三维|立体/.test(full) },
+    { tag: 'cartoon', match: (full, lower) => full.includes('卡通') || lower.includes('cartoon') },
+    { tag: 'illustration', match: (full, lower) => full.includes('插画') || full.includes('插图') || lower.includes('illustration') },
+    { tag: 'logo', match: (full, lower) => full.includes('LOGO') || full.includes('Logo') || full.includes('标志') },
+    { tag: 'branding', match: (full, lower) => full.includes('品牌') || lower.includes('brand') },
+    { tag: 'photography', match: (full, lower) => full.includes('摄影') || lower.includes('photograph') || lower.includes('photo') },
+    { tag: 'sculpture', match: (full, lower) => full.includes('雕塑') || lower.includes('sculpture') || lower.includes('statue') },
+    { tag: 'neon', match: (full, lower) => full.includes('霓虹') || lower.includes('neon') },
+    { tag: 'retro', match: (full, lower) => full.includes('复古') || lower.includes('retro') || lower.includes('vintage') },
+    { tag: 'futuristic', match: (full, lower) => full.includes('未来') || lower.includes('futuristic') || lower.includes('sci-fi') },
+    { tag: 'minimalist', match: (full, lower) => full.includes('极简') || lower.includes('minimal') },
+    { tag: 'pixel', match: (full, lower) => full.includes('像素') || lower.includes('pixel') || lower.includes('8-bit') },
+    { tag: 'paper-craft', match: (full, lower) => full.includes('纸') || full.includes('折纸') || lower.includes('origami') || lower.includes('paper') },
+    { tag: 'clay', match: (full, lower) => full.includes('粘土') || full.includes('陶土') || full.includes('泥塑') || full.includes('泥巴') || lower.includes('clay') },
+    { tag: 'felt', match: (full, lower) => full.includes('毛毡') || lower.includes('felt') || lower.includes('wool') },
+    { tag: 'toy', match: (full, lower) => full.includes('玩具') || lower.includes('toy') || lower.includes('figurine') },
+    { tag: 'character', match: (full, lower) => full.includes('角色') || lower.includes('character') || lower.includes('avatar') },
+    { tag: 'product', match: (full, lower) => full.includes('产品') || full.includes('商品') || lower.includes('product') || lower.includes('packaging') },
+    { tag: 'poster', match: (full, lower) => full.includes('海报') || lower.includes('poster') },
+    { tag: 'landscape', match: (full, lower) => full.includes('景观') || full.includes('场景') || lower.includes('landscape') || lower.includes('environment') },
+    { tag: 'architecture', match: (full, lower) => full.includes('建筑') || lower.includes('architecture') || lower.includes('building') },
+    { tag: 'fashion', match: (full, lower) => full.includes('服装') || full.includes('穿搭') || lower.includes('fashion') },
+    { tag: 'food', match: (full, lower) => full.includes('食') || full.includes('餐') || lower.includes('food') || lower.includes('cafe') || lower.includes('kitchen') },
+    { tag: 'fantasy', match: (full, lower) => full.includes('奇幻') || lower.includes('fantasy') || lower.includes('myth') },
+    { tag: 'sci-fi', match: (full, lower) => lower.includes('sci-fi') || full.includes('科幻') || lower.includes('cyber') },
+    { tag: 'ui', match: (full, lower) => /\bui\b/.test(lower) || lower.includes('user interface') || full.includes('界面') },
+    { tag: 'typography', match: (full, lower) => full.includes('字体') || full.includes('排版') || lower.includes('typography') || lower.includes('lettering') },
+    { tag: 'animal', match: (full, lower) => full.includes('动物') || lower.includes('animal') || lower.includes('creature') },
+    { tag: 'emoji', match: (full, lower) => lower.includes('emoji') || full.includes('表情包') || full.includes('表情符号') },
+    { tag: 'infographic', match: (full, lower) => full.includes('信息图') || lower.includes('infographic') || lower.includes('diagram') },
+    { tag: 'gaming', match: (full, lower) => full.includes('游戏') || lower.includes('game') || lower.includes('minecraft') },
+    { tag: 'vehicle', match: (full, lower) => lower.includes('vehicle') || full.includes('车') || lower.includes('car') || lower.includes('bike') || lower.includes('ship') },
+    { tag: 'portrait', match: (full, lower) => full.includes('肖像') || full.includes('人物') || lower.includes('portrait') },
+    { tag: 'nature', match: (full, lower) => full.includes('自然') || full.includes('花') || lower.includes('nature') || lower.includes('floral') || lower.includes('garden') },
+    { tag: 'interior', match: (full, lower) => full.includes('室内') || lower.includes('interior') || lower.includes('room') },
+    { tag: 'data-viz', match: (full, lower) => lower.includes('data') && (lower.includes('chart') || lower.includes('graph')) },
+  ];
+
+  const tags = new Set();
+  for (const matcher of tagMatchers) {
+    if (has(matcher.match)) {
+      tags.add(matcher.tag);
+    }
+  }
+
+  if (tags.size === 0) {
+    tags.add('creative');
+  }
+
+  return Array.from(tags).sort();
+}
+
+/**
+ * Parse an individual markdown file into structured prompt entries.
+ */
+function parseMarkdownFile(filePath) {
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split(/\r?\n/);
+
+  const entries = [];
+  let current = null;
+  let currentSection = null;
+  let inCodeBlock = false;
+  let codeBuffer = [];
+
+  const commitEntry = () => {
+    if (!current) return;
+    current.prompts = current.prompts || [];
+    current.examples = current.examples || [];
+    current.notes = current.notes || [];
+    current.description = (current.descriptionLines || []).join('\n').trim();
+    delete current.descriptionLines;
+    current.tags = generateTags(current);
+    current.coverImage = current.images.length > 0 ? current.images[0] : null;
+    entries.push(current);
+    current = null;
+  };
+
+  const pushCodeBuffer = () => {
+    const text = codeBuffer.join('\n').trim();
+    codeBuffer = [];
+    if (!currentSection || !text) return;
+    if (currentSection === 'prompt') {
+      current.prompts.push(text);
+    } else if (currentSection === 'example') {
+      current.examples.push(text);
+    } else if (currentSection === 'note') {
+      current.notes.push(text);
+    } else {
+      current.descriptionLines.push(text);
+    }
+  };
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+
+    if (!inCodeBlock && /^<a id="prompt-(\d+)"><\/a>/.test(trimmed)) {
+      commitEntry();
+      const [, id] = trimmed.match(/^<a id="prompt-(\d+)"><\/a>/);
+      current = {
+        id: Number(id),
+        slug: `prompt-${id}`,
+        title: '',
+        source: null,
+        images: [],
+        prompts: [],
+        examples: [],
+        notes: [],
+        descriptionLines: [],
+        originFile: path.basename(filePath),
+      };
+      currentSection = null;
+      return;
+    }
+
+    if (!current) {
+      return;
+    }
+
+    if (!inCodeBlock && /^<\/?div\b/i.test(trimmed)) {
+      return;
+    }
+
+    if (!inCodeBlock && /^##\s*案例/.test(trimmed)) {
+      const headingMatch = trimmed.match(
+        /^##\s*案例\s+(\d+)[：:]\s*(.+?)(?:\s*\(来源\s*\[([^\]]+)\]\(([^)]+)\)\))?\s*$/
+      );
+      if (headingMatch) {
+        const [, idStr, titlePart, sourceLabel, sourceLink] = headingMatch;
+        current.title = titlePart.trim();
+        if (sourceLabel && sourceLink) {
+          current.source = { name: sourceLabel.trim(), url: sourceLink.trim() };
+        }
+      } else {
+        current.title = strippedHeading(trimmed);
+      }
+      currentSection = null;
+      return;
+    }
+
+    if (!inCodeBlock && /^<img\b/.test(trimmed)) {
+      const imgMatch = trimmed.match(/src="([^"]+)"/);
+      if (imgMatch) {
+        current.images.push(normaliseImagePath(imgMatch[1]));
+      }
+      return;
+    }
+
+    if (!inCodeBlock && /^```/.test(trimmed)) {
+      inCodeBlock = true;
+      codeBuffer = [];
+      return;
+    }
+
+    if (inCodeBlock && /^```/.test(trimmed)) {
+      inCodeBlock = false;
+      pushCodeBuffer();
+      return;
+    }
+
+    if (inCodeBlock) {
+      codeBuffer.push(line);
+      return;
+    }
+
+    if (/^\*\*.*提示词.*[:：]/.test(trimmed)) {
+      currentSection = 'prompt';
+      return;
+    }
+
+    if (/^\*\*示例[:：]/.test(trimmed)) {
+      currentSection = 'example';
+      return;
+    }
+
+    if (/^\*\*提示[:：]/.test(trimmed)) {
+      const tipContent = stripMarkdownEmphasis(trimmed.replace(/^\*\*提示[:：]/, '').trim());
+      if (tipContent) {
+        current.notes.push(tipContent);
+      }
+      currentSection = 'note';
+      return;
+    }
+
+    if (trimmed.startsWith('**') && trimmed.endsWith('**') && trimmed.length > 4) {
+      // Preserve other emphasised text as description.
+      current.descriptionLines.push(stripMarkdownEmphasis(trimmed));
+      return;
+    }
+
+    if (trimmed) {
+      // Collect residual text as description for context.
+      current.descriptionLines.push(trimmed);
+    } else {
+      currentSection = null;
+    }
+  });
+
+  commitEntry();
+  return entries;
+}
+
+/**
+ * Fallback heading stripper if heading parsing fails.
+ */
+function strippedHeading(heading) {
+  return heading.replace(/^##\s*/, '').trim();
+}
+
+function ensureOutputDirectory() {
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+}
+
+function main() {
+  const files = fs
+    .readdirSync(SOURCE_DIR)
+    .filter((name) => /^\d+\.md$/.test(name))
+    .sort((a, b) => Number(a.replace('.md', '')) - Number(b.replace('.md', '')));
+
+  const readmePath = path.join(SOURCE_DIR, 'README.md');
+  if (fs.existsSync(readmePath)) {
+    files.push('README.md');
+  }
+
+  if (files.length === 0) {
+    console.error('No numbered markdown files found to parse.');
+    process.exit(1);
+  }
+
+  const allEntries = [];
+  files.forEach((fileName) => {
+    const filePath = path.join(SOURCE_DIR, fileName);
+    const fileEntries = parseMarkdownFile(filePath);
+    allEntries.push(...fileEntries);
+  });
+
+  // Sort by id descending so newest prompts appear first.
+  allEntries.sort((a, b) => b.id - a.id);
+
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    total: allEntries.length,
+    items: allEntries,
+  };
+
+  ensureOutputDirectory();
+  fs.writeFileSync(OUTPUT_FILE, JSON.stringify(payload, null, 2), 'utf8');
+
+  console.log(`Generated ${allEntries.length} prompt entries into ${path.relative(ROOT, OUTPUT_FILE)}`);
+}
+
+main();


### PR DESCRIPTION
用 codex 改造了一下，现在可以用 github pages 部署成一个静态画廊了，每个Prompt 都新增了 tag，可以搜索，点击可以查看详情，一键复制 Prompt 

参考效果： https://www.200jin.cn/gpt4o-image-prompts/

<img width="2632" height="2330" alt="image" src="https://github.com/user-attachments/assets/130a13ce-58c0-4188-9b40-a5fb3f1c0c3b" />
<img width="2632" height="2330" alt="image" src="https://github.com/user-attachments/assets/db5c43ce-de41-4731-8168-32ef894f5d2a" />
